### PR TITLE
[BugFix] HHVM sessionExists doesn't always return true.

### DIFF
--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -64,6 +64,9 @@ class SessionManager extends AbstractManager
      */
     public function sessionExists()
     {
+        if (session_status() == PHP_SESSION_ACTIVE) {
+            return true;
+        }
         $sid = defined('SID') ? constant('SID') : false;
         if ($sid !== false && $this->getId()) {
             return true;


### PR DESCRIPTION
Since the default PHP version is > 5.4, the use of PHP_SESSION_ACTIVE is allowed and fixing the issues we've been having with HHVM and sessions.
