### PR TITLE
rebuild SaveHandlerInterface and keep backward compatibility

### DIFF
--- a/src/SaveHandler/SaveHandlerInterface.php
+++ b/src/SaveHandler/SaveHandlerInterface.php
@@ -17,4 +17,5 @@ use SessionHandlerInterface;
  * @see        http://php.net/session_set_save_handler
  */
 interface SaveHandlerInterface extends SessionHandlerInterface
-{}
+{
+}

--- a/src/SaveHandler/SaveHandlerInterface.php
+++ b/src/SaveHandler/SaveHandlerInterface.php
@@ -9,55 +9,12 @@
 
 namespace Zend\Session\SaveHandler;
 
+use SessionHandlerInterface;
+
 /**
  * SaveHandler Interface
  *
  * @see        http://php.net/session_set_save_handler
  */
-interface SaveHandlerInterface
-{
-    /**
-     * Open Session - retrieve resources
-     *
-     * @param string $savePath
-     * @param string $name
-     */
-    public function open($savePath, $name);
-
-    /**
-     * Close Session - free resources
-     *
-     */
-    public function close();
-
-    /**
-     * Read session data
-     *
-     * @param string $id
-     */
-    public function read($id);
-
-    /**
-     * Write Session - commit data to resource
-     *
-     * @param string $id
-     * @param mixed $data
-     */
-    public function write($id, $data);
-
-    /**
-     * Destroy Session - remove data from resource for
-     * given session id
-     *
-     * @param string $id
-     */
-    public function destroy($id);
-
-    /**
-     * Garbage Collection - remove old session data older
-     * than $maxlifetime (in seconds)
-     *
-     * @param int $maxlifetime
-     */
-    public function gc($maxlifetime);
-}
+interface SaveHandlerInterface extends SessionHandlerInterface
+{}

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -440,13 +440,6 @@ class SessionManager extends AbstractManager
      */
     protected function registerSaveHandler(SaveHandler\SaveHandlerInterface $saveHandler)
     {
-        return session_set_save_handler(
-            [$saveHandler, 'open'],
-            [$saveHandler, 'close'],
-            [$saveHandler, 'read'],
-            [$saveHandler, 'write'],
-            [$saveHandler, 'destroy'],
-            [$saveHandler, 'gc']
-        );
+        return session_set_save_handler($saveHandler);
     }
 }


### PR DESCRIPTION
Build-in `SessionHandlerInterface` is present since PHP >= 5.4 and there is no need in describing `SaveHandlerInterface` separately
But I assume it will be breaking changes if completely remove `SaveHandlerInterface`.
