### PR TITLE
Session issue php5.6

### DIFF
--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -192,7 +192,7 @@ abstract class AbstractContainer extends ArrayObject
     {
         $storage = $this->getStorage();
         $name    = $this->getName();
-        if (!isset($storage[$name])) {
+        if (!is_array($storage[$name]) && !$storage[$name] instanceof Traversable) {
             if (!$createContainer) {
                 return;
             }


### PR DESCRIPTION
Perhaps issue itself is in FlashMessenger rather than in Session but this change resolves issue on PHP 5.5 and 5.6. For some reason isset returns true but object is empty thus exception is thrown.
Regardless of PHP configuration (session autostart and storage location) this issue is reproducible. Setting storage manually also doesn't help.
