### PR TITLE
Develop.validate session

### DIFF
--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -78,8 +78,8 @@ class SessionManager extends AbstractManager
         parent::__construct($config, $storage, $saveHandler, $validators);
         register_shutdown_function([$this, 'writeClose']);
 
-        $options = array_merge($this->defaultOptions, $options);
-        if ($options['attach_default_validators']) {
+        $this->setOptions($options);
+        if ($this->options['attach_default_validators']) {
             $this->validators = array_merge($this->defaultValidators, $validators);
         }
 

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -29,9 +29,29 @@ class SessionManager extends AbstractManager
     ];
 
     /**
+     * @var array Default session manager options
+     */
+    protected $defaultOptions = [
+        'attach_default_validators' => true,
+    ];
+
+    /**
+     * @var array Default validators
+     */
+    protected $defaultValidators = [
+        'Zend\Session\Validator\Id',
+    ];
+
+    /**
      * @var string value returned by session_name()
      */
     protected $name;
+
+
+    /**
+     * @var array Session manager options
+     */
+    protected $options;
 
     /**
      * @var EventManagerInterface Validation chain to determine if session is valid
@@ -45,16 +65,25 @@ class SessionManager extends AbstractManager
      * @param  Storage\StorageInterface|null         $storage
      * @param  SaveHandler\SaveHandlerInterface|null $saveHandler
      * @param  array                                 $validators
+     * @param  array                                 $options
      * @throws Exception\RuntimeException
      */
     public function __construct(
         Config\ConfigInterface $config = null,
         Storage\StorageInterface $storage = null,
         SaveHandler\SaveHandlerInterface $saveHandler = null,
-        array $validators = []
+        array $validators = [],
+        array $options = []
     ) {
         parent::__construct($config, $storage, $saveHandler, $validators);
         register_shutdown_function([$this, 'writeClose']);
+
+        $options = array_merge($this->defaultOptions, $options);
+        if ($options['attach_default_validators']) {
+            $this->validators = array_merge($this->defaultValidators, $validators);
+        }
+
+        $this->options = $options;
     }
 
     /**
@@ -256,6 +285,28 @@ class SessionManager extends AbstractManager
             $this->name = session_name();
         }
         return $this->name;
+    }
+
+    /**
+     * Set session options
+     *
+     * @param array $options
+     * @return SessionManager
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = array_merge($this->defaultOptions, $options);
+        return $this;
+    }
+
+    /**
+     * Get session manager options
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options ?: $this->defaultOptions;
     }
 
     /**

--- a/src/Validator/Id.php
+++ b/src/Validator/Id.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/src/Validator/Id.php
+++ b/src/Validator/Id.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Session\Validator;
+
+/**
+ * Session id validator
+ */
+class Id implements ValidatorInterface
+{
+    /**
+     * Internal data.
+     *
+     * @var string
+     */
+    protected $data;
+
+    /**
+     * Constructor
+     * get the current session id and store it in the session as 'valid data'
+     *
+     * @param null|string $data
+     */
+    public function __construct($data = null)
+    {
+        if (empty($data)) {
+            $data = session_id();
+        }
+
+        $this->data = $data;
+    }
+
+    /**
+     * isValid() - this method will determine if the current session id does not contain invalid characters.
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        $id = $this->data;
+        $saveHandler = ini_get('session.save_handler');
+        if ($saveHandler == 'cluster') { // Zend Server SC, validate only after last dash
+            $dashPos = strrpos($id, '-');
+            if ($dashPos) {
+                $id = substr($id, $dashPos + 1);
+            }
+        }
+
+        $hashBitsPerChar = ini_get('session.hash_bits_per_character');
+        if (!$hashBitsPerChar) {
+            $hashBitsPerChar = 5; // the default value
+        }
+
+        switch ($hashBitsPerChar) {
+            case 4:
+                $pattern = '^[0-9a-f]*$';
+                break;
+            case 5:
+                $pattern = '^[0-9a-v]*$';
+                break;
+            case 6:
+                $pattern = '^[0-9a-zA-Z-,]*$';
+                break;
+        }
+
+        return (bool)preg_match('#'.$pattern.'#', $id);
+    }
+
+    /**
+     * Retrieve token for validating call
+     *
+     * @return string
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * Return validator name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return __CLASS__;
+    }
+}


### PR DESCRIPTION
Issue #21 fix. Now if session id invalid, the exception 
`Exception\RuntimeException('Session validation failed')`
will thrown.
