### PR TITLE
Forwards compatibility with zend-servicemanager, zend-eventmanager v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,28 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - EVENT_MANAGER_VERSION="^2.6.2"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - EVENT_MANAGER_VERSION="^2.6.2"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 7
+    - php: 7
+      env:
+        - EVENT_MANAGER_VERSION="^2.6.2"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - EVENT_MANAGER_VERSION="^2.6.2"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:
@@ -34,6 +49,10 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
+  - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --no-update "zendframework/zend-eventmanager:^3.0" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,16 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-eventmanager": "dev-develop as 2.7",
-        "zendframework/zend-stdlib": "~2.5"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-cache": "~2.5",
-        "zendframework/zend-db": "~2.5",
-        "zendframework/zend-http": "~2.5",
-        "zendframework/zend-servicemanager": "dev-develop as 2.5",
-        "zendframework/zend-validator": "~2.5",
+        "zendframework/zend-cache": "^2.6.1",
+        "zendframework/zend-db": "^2.7",
+        "zendframework/zend-http": "^2.5.4",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-validator": "^2.6",
         "container-interop/container-interop": "^1.1",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"

--- a/src/Service/SessionConfigFactory.php
+++ b/src/Service/SessionConfigFactory.php
@@ -11,38 +11,44 @@ namespace Zend\Session\Service;
 
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Session\Config\ConfigInterface;
+use Zend\Session\Config\SessionConfig;
 
 class SessionConfigFactory implements FactoryInterface
 {
     /**
-     * Create session configuration object
+     * Create session configuration object (v3 usage).
      *
      * Uses "session_config" section of configuration to seed a ConfigInterface
      * instance. By default, Zend\Session\Config\SessionConfig will be used, but
      * you may also specify a specific implementation variant using the
      * "config_class" subkey.
      *
-     * @param  ContainerInterface         $container
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
      * @return ConfigInterface
      * @throws ServiceNotCreatedException if session_config is missing, or an
-     *         invalid config_class is used
+     *     invalid config_class is used
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $config = $container->get('config');
-        if (!isset($config['session_config']) || !is_array($config['session_config'])) {
+        if (! isset($config['session_config']) || ! is_array($config['session_config'])) {
             throw new ServiceNotCreatedException(
                 'Configuration is missing a "session_config" key, or the value of that key is not an array'
             );
         }
-        $class  = 'Zend\Session\Config\SessionConfig';
+
+        $class  = SessionConfig::class;
         $config = $config['session_config'];
         if (isset($config['config_class'])) {
-            if (!class_exists($config['config_class'])) {
+            if (! class_exists($config['config_class'])) {
                 throw new ServiceNotCreatedException(sprintf(
-                    'Invalid configuration class "%s" specified in "config_class" session configuration; must be a valid class',
+                    'Invalid configuration class "%s" specified in "config_class" session configuration; '
+                    . 'must be a valid class',
                     $config['config_class']
                 ));
             }
@@ -51,14 +57,31 @@ class SessionConfigFactory implements FactoryInterface
         }
 
         $sessionConfig = new $class();
-        if (!$sessionConfig instanceof ConfigInterface) {
+        if (! $sessionConfig instanceof ConfigInterface) {
             throw new ServiceNotCreatedException(sprintf(
-                'Invalid configuration class "%s" specified in "config_class" session configuration; must implement Zend\Session\Config\ConfigInterface',
-                $class
+                'Invalid configuration class "%s" specified in "config_class" session configuration; must implement %s',
+                $class,
+                ConfigInterface::class
             ));
         }
         $sessionConfig->setOptions($config);
 
         return $sessionConfig;
+    }
+
+    /**
+     * Create and return a config instance (v2 usage).
+     *
+     * @param ServiceLocatorInterface $services
+     * @param null|string $canonicalName
+     * @param string $requestedName
+     * @return ConfigInterface
+     */
+    public function createService(
+        ServiceLocatorInterface $services,
+        $canonicalName = null,
+        $requestedName = ConfigInterface::class
+    ) {
+        return $this($services, $requestedName);
     }
 }

--- a/src/Service/SessionManagerFactory.php
+++ b/src/Service/SessionManagerFactory.php
@@ -11,7 +11,8 @@ namespace Zend\Session\Service;
 
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Session\Config\ConfigInterface;
 use Zend\Session\Container;
 use Zend\Session\SaveHandler\SaveHandlerInterface;
@@ -30,7 +31,7 @@ class SessionManagerFactory implements FactoryInterface
     ];
 
     /**
-     * Create session manager object
+     * Create session manager object (v3 usage).
      *
      * Will consume any combination (or zero) of the following services, when
      * present, to construct the SessionManager instance:
@@ -68,37 +69,37 @@ class SessionManagerFactory implements FactoryInterface
         $validators    = [];
         $managerConfig = $this->defaultManagerConfig;
 
-        if ($container->has('Zend\Session\Config\ConfigInterface')) {
-            $config = $container->get('Zend\Session\Config\ConfigInterface');
+        if ($container->has(ConfigInterface::class)) {
+            $config = $container->get(ConfigInterface::class);
             if (!$config instanceof ConfigInterface) {
                 throw new ServiceNotCreatedException(sprintf(
                     'SessionManager requires that the %s service implement %s; received "%s"',
-                    'Zend\Session\Config\ConfigInterface',
-                    'Zend\Session\Config\ConfigInterface',
+                    ConfigInterface::class,
+                    ConfigInterface::class,
                     (is_object($config) ? get_class($config) : gettype($config))
                 ));
             }
         }
 
-        if ($container->has('Zend\Session\Storage\StorageInterface')) {
-            $storage = $container->get('Zend\Session\Storage\StorageInterface');
+        if ($container->has(StorageInterface::class)) {
+            $storage = $container->get(StorageInterface::class);
             if (!$storage instanceof StorageInterface) {
                 throw new ServiceNotCreatedException(sprintf(
                     'SessionManager requires that the %s service implement %s; received "%s"',
-                    'Zend\Session\Storage\StorageInterface',
-                    'Zend\Session\Storage\StorageInterface',
+                    StorageInterface::class,
+                    StorageInterface::class,
                     (is_object($storage) ? get_class($storage) : gettype($storage))
                 ));
             }
         }
 
-        if ($container->has('Zend\Session\SaveHandler\SaveHandlerInterface')) {
-            $saveHandler = $container->get('Zend\Session\SaveHandler\SaveHandlerInterface');
+        if ($container->has(SaveHandlerInterface::class)) {
+            $saveHandler = $container->get(SaveHandlerInterface::class);
             if (!$saveHandler instanceof SaveHandlerInterface) {
                 throw new ServiceNotCreatedException(sprintf(
                     'SessionManager requires that the %s service implement %s; received "%s"',
-                    'Zend\Session\SaveHandler\SaveHandlerInterface',
-                    'Zend\Session\SaveHandler\SaveHandlerInterface',
+                    SaveHandlerInterface::class,
+                    SaveHandlerInterface::class,
                     (is_object($saveHandler) ? get_class($saveHandler) : gettype($saveHandler))
                 ));
             }
@@ -129,5 +130,21 @@ class SessionManagerFactory implements FactoryInterface
         }
 
         return $manager;
+    }
+
+    /**
+     * Create a SessionManager instance (v2 usage)
+     *
+     * @param ServiceLocatorInterface $services
+     * @param null|string $canonicalName
+     * @param string $requestedName
+     * @return SessionManager
+     */
+    public function createService(
+        ServiceLocatorInterface $services,
+        $canonicalName = null,
+        $requestedName = SessionManager::class
+    ) {
+        return $this($services, $requestedName);
     }
 }

--- a/src/Service/StorageFactory.php
+++ b/src/Service/StorageFactory.php
@@ -11,7 +11,8 @@ namespace Zend\Session\Service;
 
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Session\Exception\ExceptionInterface as SessionException;
 use Zend\Session\Storage\Factory;
 use Zend\Session\Storage\StorageInterface;
@@ -19,7 +20,7 @@ use Zend\Session\Storage\StorageInterface;
 class StorageFactory implements FactoryInterface
 {
     /**
-     * Create session storage object
+     * Create session storage object (v3 usage).
      *
      * Uses "session_storage" section of configuration to seed a StorageInterface
      * instance. That array should contain the key "type", specifying the storage
@@ -34,14 +35,14 @@ class StorageFactory implements FactoryInterface
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $config = $container->get('config');
-        if (!isset($config['session_storage']) || !is_array($config['session_storage'])) {
+        if (! isset($config['session_storage']) || ! is_array($config['session_storage'])) {
             throw new ServiceNotCreatedException(
                 'Configuration is missing a "session_storage" key, or the value of that key is not an array'
             );
         }
 
         $config = $config['session_storage'];
-        if (!isset($config['type'])) {
+        if (! isset($config['type'])) {
             throw new ServiceNotCreatedException(
                 '"session_storage" configuration is missing a "type" key'
             );
@@ -59,5 +60,21 @@ class StorageFactory implements FactoryInterface
         }
 
         return $storage;
+    }
+
+    /**
+     * Create and return a storage instance (v2 usage).
+     *
+     * @param ServiceLocatorInterface $services
+     * @param null|string $canonicalName
+     * @param string $requestedName
+     * @return StorageInterface
+     */
+    public function createService(
+        ServiceLocatorInterface $services,
+        $canonicalName = null,
+        $requestedName = StorageInterface::class
+    ) {
+        return $this($services, $requestedName);
     }
 }

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Session;
 
+use Zend\EventManager\Event;
 use Zend\EventManager\EventManagerInterface;
 use Zend\Stdlib\ArrayUtils;
 
@@ -372,14 +373,23 @@ class SessionManager extends AbstractManager
     public function isValid()
     {
         $validator = $this->getValidatorChain();
+
+        $event = new Event();
+        $event->setName('session.validate');
+        $event->setTarget($this);
+        $event->setParams($this);
+
         $falseResult = function ($test) {
             return false === $test;
         };
-        $responses = $validator->triggerUntil($falseResult, 'session.validate', $this, [$this]);
+
+        $responses = $validator->triggerEventUntil($falseResult, $event);
+
         if ($responses->stopped()) {
             // If execution was halted, validation failed
             return false;
         }
+
         // Otherwise, we're good to go
         return true;
     }

--- a/src/Validator/ValidatorChainEM2.php
+++ b/src/Validator/ValidatorChainEM2.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Session\Validator;
+
+use Zend\EventManager\EventManager;
+
+/**
+ * Validator chain for validating sessions (for use with zend-eventmanager v2)
+ */
+class ValidatorChainEM2 extends EventManager
+{
+    use ValidatorChainTrait;
+
+    /**
+     * Attach a listener to the session validator chain.
+     *
+     * @param string $event
+     * @param null|callable $callback
+     * @param int $priority
+     * @return \Zend\Stdlib\CallbackHandler
+     */
+    public function attach($event, $callback = null, $priority = 1)
+    {
+        return $this->attachValidator($event, $callback, $priority);
+    }
+}

--- a/src/Validator/ValidatorChainEM3.php
+++ b/src/Validator/ValidatorChainEM3.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Session\Validator;
+
+use Zend\EventManager\EventManager;
+
+/**
+ * Validator chain for validating sessions (for use with zend-eventmanager v3)
+ */
+class ValidatorChainEM3 extends EventManager
+{
+    use ValidatorChainTrait;
+
+    /**
+     * Attach a listener to the session validator chain.
+     *
+     * @param string $eventName
+     * @param callable $callback
+     * @param int $priority
+     * @return \Zend\Stdlib\CallbackHandler
+     */
+    public function attach($eventName, callable $callback, $priority = 1)
+    {
+        return $this->attachValidator($eventName, $callback, $priority);
+    }
+}

--- a/src/Validator/ValidatorChainTrait.php
+++ b/src/Validator/ValidatorChainTrait.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Session\Validator;
+
+use Zend\Session\Storage\StorageInterface;
+
+/**
+ * Base trait for validator chain implementations
+ */
+trait ValidatorChainTrait
+{
+    /**
+     * @var StorageInterface
+     */
+    protected $storage;
+
+    /**
+     * Construct the validation chain
+     *
+     * Retrieves validators from session storage and attaches them.
+     *
+     * @param StorageInterface $storage
+     */
+    public function __construct(StorageInterface $storage)
+    {
+        parent::__construct();
+
+        $this->storage = $storage;
+        $validators = $storage->getMetadata('_VALID');
+        if ($validators) {
+            foreach ($validators as $validator => $data) {
+                $this->attachValidator('session.validate', [new $validator($data), 'isValid'], 1);
+            }
+        }
+    }
+
+    /**
+     * Retrieve session storage object
+     *
+     * @return StorageInterface
+     */
+    public function getStorage()
+    {
+        return $this->storage;
+    }
+
+    /**
+     * Internal implementation for attaching a listener to the
+     * session validator chain.
+     *
+     * @param  string $event
+     * @param  callable $callback
+     * @param  int $priority
+     * @return \Zend\Stdlib\CallbackHandler|callable
+     */
+    private function attachValidator($event, $callback, $priority)
+    {
+        $context = null;
+        if ($callback instanceof ValidatorInterface) {
+            $context = $callback;
+        } elseif (is_array($callback)) {
+            $test = array_shift($callback);
+            if ($test instanceof ValidatorInterface) {
+                $context = $test;
+            }
+            array_unshift($callback, $test);
+        }
+        if ($context instanceof ValidatorInterface) {
+            $data = $context->getData();
+            $name = $context->getName();
+            $this->getStorage()->setMetadata('_VALID', [$name => $data]);
+        }
+
+        $listener = parent::attach($event, $callback, $priority);
+        return $listener;
+    }
+}

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -6,86 +6,25 @@
  * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace Zend\Session;
 
-use Zend\EventManager\Event;
-use Zend\EventManager\EventManager;
-use Zend\EventManager\SharedEventManagerInterface;
-use Zend\Session\Storage\StorageInterface as Storage;
-use Zend\Session\Validator\ValidatorInterface as Validator;
+use Zend\EventManager\GlobalEventManager;
 
 /**
- * Validator chain for validating sessions
+ * Polyfill for ValidatorChain
+ *
+ * The definitions for EventManagerInterface::attach differ between versions 2
+ * and 3 of zend-eventmanager, which makes it impossible to override the method
+ * in a way that is compatible with both. To get around that, we define 2
+ * classes, one targeting each major version of zend-eventmanager, each
+ * sharing the same trait, and each defining attach() per the EM version they
+ * target. This file then aliases the appropriate one to `ValidatorChain`,
+ * based on which version of the EM is present. Since the `GlobalEventManager`
+ * is only present in v2, we can use that as our test.
  */
-class ValidatorChain extends EventManager
-{
-    /**
-     * @var Storage
-     */
-    protected $storage;
-
-    /**
-     * @var Event
-     */
-    protected $eventPrototype;
-
-    /**
-     * Construct the validation chain
-     *
-     * Retrieves validators from session storage and attaches them.
-     *
-     * @param Storage $storage
-     */
-    public function __construct(Storage $storage)
-    {
-        parent::__construct();
-
-        $this->storage = $storage;
-        $validators = $storage->getMetadata('_VALID');
-        if ($validators) {
-            foreach ($validators as $validator => $data) {
-                $this->attach('session.validate', [new $validator($data), 'isValid']);
-            }
-        }
-    }
-
-    /**
-     * Attach a listener to the session validator chain
-     *
-     * @param  string $eventName
-     * @param  callable $callback
-     * @param  int $priority
-     * @return \Zend\Stdlib\CallbackHandler|callable
-     */
-    public function attach($eventName, callable $callback, $priority = 1)
-    {
-        $context = null;
-        if ($callback instanceof Validator) {
-            $context = $callback;
-        } elseif (is_array($callback)) {
-            $test = array_shift($callback);
-            if ($test instanceof Validator) {
-                $context = $test;
-            }
-            array_unshift($callback, $test);
-        }
-        if ($context instanceof Validator) {
-            $data = $context->getData();
-            $name = $context->getName();
-            $this->getStorage()->setMetadata('_VALID', [$name => $data]);
-        }
-
-        $listener = parent::attach($eventName, $callback, $priority);
-        return $listener;
-    }
-
-    /**
-     * Retrieve session storage object
-     *
-     * @return Storage
-     */
-    public function getStorage()
-    {
-        return $this->storage;
-    }
+if (class_exists(GlobalEventManager::class)) {
+    class_alias(Validator\ValidatorChainEM2::class, ValidatorChain::class);
+} else {
+    class_alias(Validator\ValidatorChainEM3::class, ValidatorChain::class);
 }

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -35,12 +35,10 @@ class ValidatorChain extends EventManager
      * Retrieves validators from session storage and attaches them.
      *
      * @param Storage $storage
-     * @param SharedEventManagerInterface $sharedEventManager
-     * @param array $identifiers
      */
-    public function __construct(Storage $storage, SharedEventManagerInterface $sharedEventManager = null, array $identifiers = [])
+    public function __construct(Storage $storage)
     {
-        parent::__construct($sharedEventManager, $identifiers);
+        parent::__construct();
 
         $this->storage = $storage;
         $validators = $storage->getMetadata('_VALID');
@@ -57,7 +55,7 @@ class ValidatorChain extends EventManager
      * @param  string $eventName
      * @param  callable $callback
      * @param  int $priority
-     * @return \Zend\Stdlib\CallbackHandler
+     * @return \Zend\Stdlib\CallbackHandler|callable
      */
     public function attach($eventName, callable $callback, $priority = 1)
     {

--- a/test/Service/ContainerAbstractServiceFactoryTest.php
+++ b/test/Service/ContainerAbstractServiceFactoryTest.php
@@ -9,8 +9,14 @@
 
 namespace ZendTest\Session\Service;
 
+use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
+use Zend\Session\Container;
+use Zend\Session\ManagerInterface;
+use Zend\Session\Service\ContainerAbstractServiceFactory;
+use Zend\Session\Service\SessionManagerFactory;
 use Zend\Session\Storage\ArrayStorage;
+use Zend\Session\Storage\StorageInterface;
 
 /**
  * @group      Zend_Session
@@ -30,19 +36,20 @@ class ContainerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $config = [
+        $config = new Config([
             'services' => [
                 'config' => $this->config,
-                'Zend\Session\Storage\StorageInterface' => new ArrayStorage(),
+                StorageInterface::class => new ArrayStorage(),
             ],
             'factories' => [
-                'Zend\Session\ManagerInterface' => 'Zend\Session\Service\SessionManagerFactory',
+                ManagerInterface::class => SessionManagerFactory::class,
             ],
             'abstract_factories' => [
-                'Zend\Session\Service\ContainerAbstractServiceFactory',
+                ContainerAbstractServiceFactory::class,
             ],
-        ];
-        $this->services = new ServiceManager($config);
+        ]);
+        $this->services = new ServiceManager();
+        $config->configureServiceManager($this->services);
     }
 
     public function validContainers()
@@ -63,7 +70,7 @@ class ContainerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->services->has($serviceName), "Container does not have service by name '$serviceName'");
         $container = $this->services->get($serviceName);
-        $this->assertInstanceOf('Zend\Session\Container', $container);
+        $this->assertInstanceOf(Container::class, $container);
         $this->assertEquals($containerName, $container->getName());
     }
 
@@ -74,7 +81,7 @@ class ContainerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->services->has($serviceName), "Container does not have service by name '$serviceName'");
         $container = $this->services->get($serviceName);
-        $this->assertSame($this->services->get('Zend\Session\ManagerInterface'), $container->getManager());
+        $this->assertSame($this->services->get(ManagerInterface::class), $container->getManager());
     }
 
     public function invalidContainers()

--- a/test/Service/SessionConfigFactoryTest.php
+++ b/test/Service/SessionConfigFactoryTest.php
@@ -9,7 +9,12 @@
 
 namespace ZendTest\Session\Service;
 
+use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
+use Zend\Session\Config\ConfigInterface;
+use Zend\Session\Config\SessionConfig;
+use Zend\Session\Config\StandardConfig;
+use Zend\Session\Service\SessionConfigFactory;
 
 /**
  * @group      Zend_Session
@@ -19,57 +24,46 @@ class SessionConfigFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $config = [
+        $config = new Config([
             'factories' => [
-                'Zend\Session\Config\ConfigInterface' => 'Zend\Session\Service\SessionConfigFactory',
+                ConfigInterface::class => SessionConfigFactory::class,
             ],
-        ];
-        $this->services = new ServiceManager($config);
+        ]);
+        $this->services = new ServiceManager();
+        $config->configureServiceManager($this->services);
     }
 
     public function testCreatesSessionConfigByDefault()
     {
-        $this->services->configure([
-            'services' => [
-                'config' => [
-                    'session_config' => [],
-                ],
-            ],
+        $this->services->setService('config', [
+            'session_config' => [],
         ]);
-        $config = $this->services->get('Zend\Session\Config\ConfigInterface');
-        $this->assertInstanceOf('Zend\Session\Config\SessionConfig', $config);
+        $config = $this->services->get(ConfigInterface::class);
+        $this->assertInstanceOf(SessionConfig::class, $config);
     }
 
     public function testCanCreateAlternateSessionConfigTypeViaConfigClassKey()
     {
-        $this->services->configure([
-            'services' => [
-                'config' => [
-                    'session_config' => [
-                        'config_class' => 'Zend\Session\Config\StandardConfig',
-                    ],
-                ],
+        $this->services->setService('config', [
+            'session_config' => [
+                'config_class' => StandardConfig::class,
             ],
         ]);
-        $config = $this->services->get('Zend\Session\Config\ConfigInterface');
-        $this->assertInstanceOf('Zend\Session\Config\StandardConfig', $config);
-        // Since SessionConfig extends StandardConfig, need to test that it's not that
-        $this->assertNotInstanceOf('Zend\Session\Config\SessionConfig', $config);
+        $config = $this->services->get(ConfigInterface::class);
+        $this->assertInstanceOf(StandardConfig::class, $config);
+        // Since SessionConfig extends StandardConfig, need to assert not SessionConfig
+        $this->assertNotInstanceOf(SessionConfig::class, $config);
     }
 
     public function testServiceReceivesConfiguration()
     {
-        $this->services->configure([
-            'services' => [
-                'config' => [
-                    'session_config' => [
-                        'config_class' => 'Zend\Session\Config\StandardConfig',
-                        'name'         => 'zf2',
-                    ],
-                ],
+        $this->services->setService('config', [
+            'session_config' => [
+                'config_class' => StandardConfig::class,
+                'name'         => 'zf2',
             ],
         ]);
-        $config = $this->services->get('Zend\Session\Config\ConfigInterface');
+        $config = $this->services->get(ConfigInterface::class);
         $this->assertEquals('zf2', $config->getName());
     }
 }

--- a/test/Service/StorageFactoryTest.php
+++ b/test/Service/StorageFactoryTest.php
@@ -9,7 +9,13 @@
 
 namespace ZendTest\Session\Service;
 
+use Zend\ServiceManager\Config;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceManager;
+use Zend\Session\Service\StorageFactory;
+use Zend\Session\Storage\ArrayStorage;
+use Zend\Session\Storage\SessionArrayStorage;
+use Zend\Session\Storage\StorageInterface;
 
 /**
  * @group      Zend_Session
@@ -19,12 +25,13 @@ class StorageFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $config = [
+        $config = new Config([
             'factories' => [
-                'Zend\Session\Storage\StorageInterface' => 'Zend\Session\Service\StorageFactory',
+                StorageInterface::class => StorageFactory::class,
             ],
-        ];
-        $this->services = new ServiceManager($config);
+        ]);
+        $this->services = new ServiceManager();
+        $config->configureServiceManager($this->services);
     }
 
     public function sessionStorageConfig()
@@ -39,17 +46,17 @@ class StorageFactoryTest extends \PHPUnit_Framework_TestCase
                         ],
                     ],
                 ],
-            ], 'Zend\Session\Storage\ArrayStorage'],
+            ], ArrayStorage::class],
             'array-storage-fqcn' => [[
                 'session_storage' => [
-                    'type' => 'Zend\Session\Storage\ArrayStorage',
+                    'type' => ArrayStorage::class,
                     'options' => [
                         'input' => [
                             'foo' => 'bar',
                         ],
                     ],
                 ],
-            ], 'Zend\Session\Storage\ArrayStorage'],
+            ], ArrayStorage::class],
             'session-array-storage-short' => [[
                 'session_storage' => [
                     'type' => 'SessionArrayStorage',
@@ -59,17 +66,17 @@ class StorageFactoryTest extends \PHPUnit_Framework_TestCase
                         ],
                     ],
                 ],
-            ], 'Zend\Session\Storage\SessionArrayStorage'],
+            ], SessionArrayStorage::class],
             'session-array-storage-fqcn' => [[
                 'session_storage' => [
-                    'type' => 'Zend\Session\Storage\SessionArrayStorage',
+                    'type' => SessionArrayStorage::class,
                     'options' => [
                         'input' => [
                             'foo' => 'bar',
                         ],
                     ],
                 ],
-            ], 'Zend\Session\Storage\SessionArrayStorage'],
+            ], SessionArrayStorage::class],
         ];
     }
 
@@ -78,12 +85,8 @@ class StorageFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testUsesConfigurationToCreateStorage($config, $class)
     {
-        $this->services->configure([
-            'services' => [
-                'config' => $config
-            ]
-        ]);
-        $storage = $this->services->get('Zend\Session\Storage\StorageInterface');
+        $this->services->setService('config', $config);
+        $storage = $this->services->get(StorageInterface::class);
         $this->assertInstanceOf($class, $storage);
         $test = $storage->toArray();
         $this->assertEquals($config['session_storage']['options']['input'], $test);
@@ -126,12 +129,8 @@ class StorageFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidConfigurationRaisesServiceNotCreatedException($config)
     {
-        $this->services->configure([
-            'services' => [
-                'config' => $config
-            ]
-        ]);
-        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotCreatedException');
-        $storage = $this->services->get('Zend\Session\Storage\StorageInterface');
+        $this->services->setService('config', $config);
+        $this->setExpectedException(ServiceNotCreatedException::class);
+        $storage = $this->services->get(StorageInterface::class);
     }
 }

--- a/test/TestAsset/TestManager.php
+++ b/test/TestAsset/TestManager.php
@@ -11,13 +11,15 @@ namespace ZendTest\Session\TestAsset;
 
 use Zend\EventManager\EventManagerInterface;
 use Zend\Session\AbstractManager;
+use Zend\Session\Configuration\StandardConfig;
+use Zend\Session\Storage\ArrayStorage;
 
 class TestManager extends AbstractManager
 {
     public $started = false;
 
-    protected $configDefaultClass = 'Zend\\Session\\Configuration\\StandardConfig';
-    protected $storageDefaultClass = 'Zend\\Session\\Storage\\ArrayStorage';
+    protected $configDefaultClass = StandardConfig::class;
+    protected $storageDefaultClass = ArrayStorage::class;
 
     public function start()
     {
@@ -30,7 +32,8 @@ class TestManager extends AbstractManager
     }
 
     public function stop()
-    {}
+    {
+    }
 
     public function writeClose()
     {
@@ -38,40 +41,50 @@ class TestManager extends AbstractManager
     }
 
     public function getName()
-    {}
+    {
+    }
 
     public function setName($name)
-    {}
+    {
+    }
 
     public function getId()
-    {}
+    {
+    }
 
     public function setId($id)
-    {}
+    {
+    }
 
     public function regenerateId()
-    {}
+    {
+    }
 
     public function rememberMe($ttl = null)
-    {}
+    {
+    }
 
     public function forgetMe()
-    {}
-
+    {
+    }
 
     public function setValidatorChain(EventManagerInterface $chain)
-    {}
+    {
+    }
 
     public function getValidatorChain()
-    {}
+    {
+    }
 
     public function isValid()
-    {}
-
+    {
+    }
 
     public function sessionExists()
-    {}
+    {
+    }
 
     public function expireSessionCookie()
-    {}
+    {
+    }
 }


### PR DESCRIPTION
This patch makes the code base forwards compatible with zend-servicemanager and zend-eventmanager v3. Changes include:
- Ensuring factories and abstract factories implement both the v2 and v3 methods.
- Rewriting calls to `triggerUntil` to instead use `triggerEventUntil()`.
- Settting all dependencies to known-stable, forwards-compatible versions.
- Setting up test jobs for both v2 and v3 components.
