### PR TITLE
Extract constructor from trait to implementations

### DIFF
--- a/src/Validator/ValidatorChainEM3.php
+++ b/src/Validator/ValidatorChainEM3.php
@@ -9,6 +9,7 @@
 namespace Zend\Session\Validator;
 
 use Zend\EventManager\EventManager;
+use Zend\Session\Storage\StorageInterface;
 
 /**
  * Validator chain for validating sessions (for use with zend-eventmanager v3)
@@ -16,6 +17,28 @@ use Zend\EventManager\EventManager;
 class ValidatorChainEM3 extends EventManager
 {
     use ValidatorChainTrait;
+
+    /**
+     * Construct the validation chain
+     *
+     * Retrieves validators from session storage and attaches them.
+     *
+     * Duplicated in ValidatorChainEM2 to prevent trait collision with parent.
+     *
+     * @param StorageInterface $storage
+     */
+    public function __construct(StorageInterface $storage)
+    {
+        parent::__construct();
+
+        $this->storage = $storage;
+        $validators = $storage->getMetadata('_VALID');
+        if ($validators) {
+            foreach ($validators as $validator => $data) {
+                $this->attachValidator('session.validate', [new $validator($data), 'isValid'], 1);
+            }
+        }
+    }
 
     /**
      * Attach a listener to the session validator chain.

--- a/src/Validator/ValidatorChainTrait.php
+++ b/src/Validator/ValidatorChainTrait.php
@@ -21,26 +21,6 @@ trait ValidatorChainTrait
     protected $storage;
 
     /**
-     * Construct the validation chain
-     *
-     * Retrieves validators from session storage and attaches them.
-     *
-     * @param StorageInterface $storage
-     */
-    public function __construct(StorageInterface $storage)
-    {
-        parent::__construct();
-
-        $this->storage = $storage;
-        $validators = $storage->getMetadata('_VALID');
-        if ($validators) {
-            foreach ($validators as $validator => $data) {
-                $this->attachValidator('session.validate', [new $validator($data), 'isValid'], 1);
-            }
-        }
-    }
-
-    /**
      * Retrieve session storage object
      *
      * @return StorageInterface


### PR DESCRIPTION
Per zendframework/zf2#7676, users are reporting a trait collision due to the `ValidatorChainTrait` defining a constructor, when the classes composing the trait are also extending a class with a constructor. To resolve the issue, I've extracted the constructor into each implementing class.
