### PR TITLE
Better polyfill support for ValidatorChain

### DIFF
--- a/src/Validator/AbstractValidatorChainEM2.php
+++ b/src/Validator/AbstractValidatorChainEM2.php
@@ -12,9 +12,9 @@ use Zend\EventManager\EventManager;
 use Zend\Session\Storage\StorageInterface;
 
 /**
- * Validator chain for validating sessions (for use with zend-eventmanager v2)
+ * Abstract validator chain for validating sessions (for use with zend-eventmanager v2).
  */
-class ValidatorChainEM2 extends EventManager
+abstract class AbstractValidatorChainEM2 extends EventManager
 {
     use ValidatorChainTrait;
 

--- a/src/Validator/AbstractValidatorChainEM3.php
+++ b/src/Validator/AbstractValidatorChainEM3.php
@@ -12,9 +12,9 @@ use Zend\EventManager\EventManager;
 use Zend\Session\Storage\StorageInterface;
 
 /**
- * Validator chain for validating sessions (for use with zend-eventmanager v3)
+ * Abstract validator chain for validating sessions (for use with zend-eventmanager v3)
  */
-class ValidatorChainEM3 extends EventManager
+abstract class AbstractValidatorChainEM3 extends EventManager
 {
     use ValidatorChainTrait;
 

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -12,19 +12,32 @@ namespace Zend\Session;
 use Zend\EventManager\GlobalEventManager;
 
 /**
- * Polyfill for ValidatorChain
+ * Polyfill for AbstractValidatorChain.
  *
  * The definitions for EventManagerInterface::attach differ between versions 2
  * and 3 of zend-eventmanager, which makes it impossible to override the method
- * in a way that is compatible with both. To get around that, we define 2
- * classes, one targeting each major version of zend-eventmanager, each
- * sharing the same trait, and each defining attach() per the EM version they
- * target. This file then aliases the appropriate one to `ValidatorChain`,
+ * in a way that is compatible with both.
+ *
+ * To get around that, we define 2 abstract classes, one targeting each major
+ * version of zend-eventmanager, and each defining attach() per the EM version
+ * they target.
+ *
+ * This conditional below then aliases the appropriate one to `AbstractValidatorChain`,
  * based on which version of the EM is present. Since the `GlobalEventManager`
  * is only present in v2, we can use that as our test.
  */
 if (class_exists(GlobalEventManager::class)) {
-    class_alias(Validator\ValidatorChainEM2::class, ValidatorChain::class);
+    class_alias(Validator\AbstractValidatorChainEM2::class, AbstractValidatorChain::class);
 } else {
-    class_alias(Validator\ValidatorChainEM3::class, ValidatorChain::class);
+    class_alias(Validator\AbstractValidatorChainEM3::class, AbstractValidatorChain::class);
+}
+
+/**
+ * Validator chain implementation.
+ *
+ * Extends the zend-eventmanager-version-specific base class implementation
+ * as polyfilled above.
+ */
+class ValidatorChain extends AbstractValidatorChain
+{
 }


### PR DESCRIPTION
In `src/ValidatorChain.php`, instead of aliasing `ValidatorChain` to the appropriate zend-eventmanager-specific validator chain implementation, it now aliases those to `AbstractValidatorChain`, and defines the `ValidatorChain` class as an extension of `AbstractValidatorChain`. As such, I've also marked the two base implementations as abstract (and renamed them).

Fixes #31
