### PR TITLE
Expose package as standalone config-provider / ZF component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,10 @@
         "branch-alias": {
             "dev-master": "2.6-dev",
             "dev-develop": "2.7-dev"
+        },
+        "zf": {
+            "component": "Zend\\Session",
+            "config-provider": "Zend\\Session\\ConfigProvider"
         }
     },
     "autoload-dev": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-session for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Session;
+
+class ConfigProvider
+{
+    /**
+     * Retrieve configuration for zend-session.
+     *
+     * @return array
+     */
+    public function __invoke()
+    {
+        return [
+            'dependencies' => $this->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Retrieve dependency config for zend-session.
+     *
+     * @return array
+     */
+    public function getDependencyConfig()
+    {
+        return [
+            'abstract_factories' => [
+                Service\ContainerAbstractServiceFactory::class,
+            ],
+            'aliases' => [
+                SessionManager::class => ManagerInterface::class,
+            ],
+            'factories' => [
+                Config\ConfigInterface::class => Service\SessionConfigFactory::class,
+                ManagerInterface::class => Service\SessionManagerFactory::class,
+                Storage\StorageInterface::class => Service\StorageFactory::class,
+            ],
+        ];
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-session for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Session;
+
+class Module
+{
+    /**
+     * Retrieve default zend-session config for zend-mvc context.
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        $provider = new ConfigProvider();
+        return [
+            'service_manager' => $provider->getDependencyConfig(),
+        ];
+    }
+}


### PR DESCRIPTION
Adds:
- `ConfigProvider`, which maps the default services offered by the package.
- `Module`, which does the same, for zend-mvc contexts.
