### PR TITLE
[Hotfix] MongoDB expireAfterSeconds index currently not working properly

### DIFF
--- a/src/SaveHandler/MongoDB.php
+++ b/src/SaveHandler/MongoDB.php
@@ -87,7 +87,7 @@ class MongoDB implements SaveHandlerInterface
     {
         // Note: session save path is not used
         $this->sessionName = $name;
-        $this->lifetime    = ini_get('session.gc_maxlifetime');
+        $this->lifetime    = (int) ini_get('session.gc_maxlifetime');
 
         $this->mongoCollection = $this->mongoClient->selectCollection(
             $this->options->getDatabase(),


### PR DESCRIPTION
@weierophinney This is an important hotfix. The liftetime must be an integer, otherwise the expireAfterSeconds index (disabled at default) will not work and sessions are not deleted.

If people already use it, they must delete the session collection or must update the lifetime data type and index. Otherwise, no new sessions can be created.

Here is the log:

``` bash
mongodb | 2016-04-14T08:27:48.570+0000 E INDEX    [TTLMonitor] ttl indexes require the expireAfterSeconds field to be numeric but received a type of String, skipping ttl job for: { v: 1, key: { modified: 1 }, name: "modified_1", expireAfterSeconds: "10", ns: "session" }
```
