### PR TITLE
PHP 7 requires return of a string in any case

### DIFF
--- a/src/SaveHandler/Cache.php
+++ b/src/SaveHandler/Cache.php
@@ -81,7 +81,7 @@ class Cache implements SaveHandlerInterface
      */
     public function read($id)
     {
-        return $this->getCacheStorage()->getItem($id);
+        return (string) $this->getCacheStorage()->getItem($id);
     }
 
     /**

--- a/src/SaveHandler/DbTableGateway.php
+++ b/src/SaveHandler/DbTableGateway.php
@@ -102,7 +102,7 @@ class DbTableGateway implements SaveHandlerInterface
         if ($row = $rows->current()) {
             if ($row->{$this->options->getModifiedColumn()} +
                 $row->{$this->options->getLifetimeColumn()} > time()) {
-                return $row->{$this->options->getDataColumn()};
+                return (string) $row->{$this->options->getDataColumn()};
             }
             $this->destroy($id);
         }

--- a/test/SaveHandler/CacheTest.php
+++ b/test/SaveHandler/CacheTest.php
@@ -103,4 +103,17 @@ class CacheTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->testArray, unserialize($saveHandler->read($id)));
     }
+
+    public function testReadShouldAlwaysReturnString()
+    {
+        $cacheStorage = $this->prophesize('Zend\Cache\Storage\StorageInterface');
+        $cacheStorage->getItem('242')->willReturn(null);
+        $this->usedSaveHandlers[] = $saveHandler = new Cache($cacheStorage->reveal());
+
+        $id = '242';
+
+        $data = $saveHandler->read($id);
+
+        $this->assertTrue(is_string($data));
+    }
 }

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -123,6 +123,18 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->testArray, unserialize($saveHandler->read($id)));
     }
 
+    public function testReadShouldAlwaysReturnString()
+    {
+        $this->usedSaveHandlers[] = $saveHandler = new DbTableGateway($this->tableGateway, $this->options);
+        $saveHandler->open('savepath', 'sessionname');
+
+        $id = '242';
+
+        $data = $saveHandler->read($id);
+
+        $this->assertTrue(is_string($data));
+    }
+
     /**
      * Sets up the database connection and creates the table for session data
      *

--- a/test/SaveHandler/MongoDBTest.php
+++ b/test/SaveHandler/MongoDBTest.php
@@ -165,5 +165,4 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(is_string($data));
     }
-
 }

--- a/test/SaveHandler/MongoDBTest.php
+++ b/test/SaveHandler/MongoDBTest.php
@@ -153,4 +153,17 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase
         $saveHandler->open('savepath', 'sessionname_changed');
         $saveHandler->write($id, serialize($data));
     }
+
+    public function testReadShouldAlwaysReturnString()
+    {
+        $saveHandler = new MongoDB($this->mongoClient, $this->options);
+        $this->assertTrue($saveHandler->open('savepath', 'sessionname'));
+
+        $id = '242';
+
+        $data = $saveHandler->read($id);
+
+        $this->assertTrue(is_string($data));
+    }
+
 }


### PR DESCRIPTION
If `read` returns anything else than a string it will fail with `PHP Catchable fatal error: session_regenerate_id(): Failed to create(read) session ID: user`. 
PHP 7 requires that reading always returns a string, regardless the existence of data. 
Fixes #35.

Might cover #41 as well.
