### PR TITLE
skip session regenerate id when session is not started

### DIFF
--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -320,7 +320,10 @@ class SessionManager extends AbstractManager
      */
     public function regenerateId($deleteOldSession = true)
     {
-        session_regenerate_id((bool) $deleteOldSession);
+        if ($this->sessionExists()) { 
+            session_regenerate_id((bool) $deleteOldSession);
+        }
+
         return $this;
     }
 

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -436,6 +436,17 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testRegenerateIdDoesNothingWhenSessioIsNotStarted()
+    {
+        $origId = $this->manager->getId();
+        $this->manager->regenerateId();
+        $this->assertEquals($origId, $this->manager->getId());
+        $this->assertEquals('', $this->manager->getId());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testRegeneratingIdAfterSessionStartedShouldSendExpireCookie()
     {
         if (!extension_loaded('xdebug')) {


### PR DESCRIPTION
Original pull request: https://github.com/zendframework/zend-session/pull/41
Fix php7 session regenerate id fails if session doesn't exist: php/php-src#1739
