### PR TITLE
Fix php 7 issues

### DIFF
--- a/src/SaveHandler/Cache.php
+++ b/src/SaveHandler/Cache.php
@@ -81,7 +81,7 @@ class Cache implements SaveHandlerInterface
      */
     public function read($id)
     {
-        return $this->getCacheStorage()->getItem($id);
+        return (string) $this->getCacheStorage()->getItem($id);
     }
 
     /**

--- a/src/SaveHandler/DbTableGateway.php
+++ b/src/SaveHandler/DbTableGateway.php
@@ -149,10 +149,14 @@ class DbTableGateway implements SaveHandlerInterface
      */
     public function destroy($id)
     {
-        return (bool) $this->tableGateway->delete([
+        $exists = (bool) $this->read($id);
+        
+        $deleted = (bool) $this->tableGateway->delete([
             $this->options->getIdColumn()   => $id,
             $this->options->getNameColumn() => $this->sessionName,
-        ]);
+        ]); 
+        
+        return $exists ? $deleted : true;
     }
 
     /**

--- a/src/SaveHandler/DbTableGateway.php
+++ b/src/SaveHandler/DbTableGateway.php
@@ -150,12 +150,12 @@ class DbTableGateway implements SaveHandlerInterface
     public function destroy($id)
     {
         $exists = (bool) $this->read($id);
-        
+
         $deleted = (bool) $this->tableGateway->delete([
             $this->options->getIdColumn()   => $id,
             $this->options->getNameColumn() => $this->sessionName,
-        ]); 
-        
+        ]);
+
         return $exists ? $deleted : true;
     }
 

--- a/src/SaveHandler/DbTableGateway.php
+++ b/src/SaveHandler/DbTableGateway.php
@@ -102,7 +102,7 @@ class DbTableGateway implements SaveHandlerInterface
         if ($row = $rows->current()) {
             if ($row->{$this->options->getModifiedColumn()} +
                 $row->{$this->options->getLifetimeColumn()} > time()) {
-                return $row->{$this->options->getDataColumn()};
+                return (string) $row->{$this->options->getDataColumn()};
             }
             $this->destroy($id);
         }

--- a/test/SaveHandler/CacheTest.php
+++ b/test/SaveHandler/CacheTest.php
@@ -103,4 +103,17 @@ class CacheTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->testArray, unserialize($saveHandler->read($id)));
     }
+
+    public function testReadShouldAlwaysReturnString()
+    {
+        $cacheStorage = $this->prophesize('Zend\Cache\Storage\StorageInterface');
+        $cacheStorage->getItem('242')->willReturn(null);
+        $this->usedSaveHandlers[] = $saveHandler = new Cache($cacheStorage->reveal());
+
+        $id = '242';
+
+        $data = $saveHandler->read($id);
+
+        $this->assertTrue(is_string($data));
+    }
 }

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -49,7 +49,7 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test data container.
-     * 
+     *
      * @var array
      */
     private $testArray;

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -123,6 +123,18 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->testArray, unserialize($saveHandler->read($id)));
     }
 
+    public function testReadShouldAlwaysReturnString()
+    {
+        $this->usedSaveHandlers[] = $saveHandler = new DbTableGateway($this->tableGateway, $this->options);
+        $saveHandler->open('savepath', 'sessionname');
+
+        $id = '242';
+
+        $data = $saveHandler->read($id);
+
+        $this->assertTrue(is_string($data));
+    }
+
     /**
      * Sets up the database connection and creates the table for session data
      *

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -48,6 +48,13 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
     protected $usedSaveHandlers = [];
 
     /**
+     * Test data container.
+     * 
+     * @var array
+     */
+    private $testArray;
+
+    /**
      * Setup performed prior to each test method
      *
      * @return void
@@ -135,10 +142,36 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_string($data));
     }
 
+    public function testDestroyReturnsTrueEvenWhenSessionDoesNotExist()
+    {
+        $this->usedSaveHandlers[] = $saveHandler = new DbTableGateway($this->tableGateway, $this->options);
+        $saveHandler->open('savepath', 'sessionname');
+
+        $id = '242';
+
+        $result = $saveHandler->destroy($id);
+
+        $this->assertTrue($result);
+    }
+
+    public function testDestroyReturnsTrueWhenSessionIsDeleted()
+    {
+        $this->usedSaveHandlers[] = $saveHandler = new DbTableGateway($this->tableGateway, $this->options);
+        $saveHandler->open('savepath', 'sessionname');
+
+        $id = '242';
+
+        $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
+
+        $result = $saveHandler->destroy($id);
+
+        $this->assertTrue($result);
+    }
+
     /**
      * Sets up the database connection and creates the table for session data
      *
-     * @param  Zend\Session\SaveHandler\DbTableGatewayOptions $options
+     * @param  \Zend\Session\SaveHandler\DbTableGatewayOptions $options
      * @return void
      */
     protected function setupDb(DbTableGatewayOptions $options)

--- a/test/SaveHandler/MongoDBTest.php
+++ b/test/SaveHandler/MongoDBTest.php
@@ -165,5 +165,4 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(is_string($data));
     }
-
 }

--- a/test/SaveHandler/MongoDBTest.php
+++ b/test/SaveHandler/MongoDBTest.php
@@ -153,4 +153,17 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase
         $saveHandler->open('savepath', 'sessionname_changed');
         $saveHandler->write($id, serialize($data));
     }
+
+    public function testReadShouldAlwaysReturnString()
+    {
+        $saveHandler = new MongoDB($this->mongoClient, $this->options);
+        $this->assertTrue($saveHandler->open('savepath', 'sessionname'));
+
+        $id = '242';
+
+        $data = $saveHandler->read($id);
+
+        $this->assertTrue(is_string($data));
+    }
+
 }


### PR DESCRIPTION
This PR supersedes #44. It contains fixes for 
- `read` not returning always a string, fixes #35 and #41.
- `destroy` wrongly returning false when session doesn't exist. Fixes #36 and #42.

**read**
If `read` returns anything else than a string it will fail with `PHP Catchable fatal error: session_regenerate_id(): Failed to create(read) session ID: user`. PHP 7 requires that reading always returns a string, regardless the existence of data. 

**destroy**
When `session_regenerate_id()` is called right after `session_start()` php tries to destroy a session that doesn't exist yet. Currently `DbTableGateway` bases its return value on the affected rows and therefore causing `destroy()` to wrongly return `false` when the session doesn't exist yet. PHP 7 will then fail with `session_regenerate_id(): Session object destruction failed. ID: user (path: )`. 
