### PR TITLE
Prevent recursion in DbTableGateway save handler.

### DIFF
--- a/src/SaveHandler/DbTableGateway.php
+++ b/src/SaveHandler/DbTableGateway.php
@@ -90,9 +90,10 @@ class DbTableGateway implements SaveHandlerInterface
      * Read session data
      *
      * @param string $id
+     * @param bool $destroyExpired Optional; true by default
      * @return string
      */
-    public function read($id)
+    public function read($id, $destroyExpired = true)
     {
         $rows = $this->tableGateway->select([
             $this->options->getIdColumn()   => $id,
@@ -104,7 +105,9 @@ class DbTableGateway implements SaveHandlerInterface
                 $row->{$this->options->getLifetimeColumn()} > time()) {
                 return (string) $row->{$this->options->getDataColumn()};
             }
-            $this->destroy($id);
+            if ($destroyExpired) {
+                $this->destroy($id);
+            }
         }
         return '';
     }
@@ -149,7 +152,7 @@ class DbTableGateway implements SaveHandlerInterface
      */
     public function destroy($id)
     {
-        if (! (bool) $this->read($id)) {
+        if (! (bool) $this->read($id, false)) {
             return true;
         }
 

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -13,6 +13,7 @@ use Zend\Session\SaveHandler\DbTableGateway;
 use Zend\Session\SaveHandler\DbTableGatewayOptions;
 use Zend\Db\Adapter\Adapter;
 use Zend\Db\TableGateway\TableGateway;
+use ZendTest\Session\TestAsset\TestDbTableGatewaySaveHandler;
 
 /**
  * Unit testing for DbTableGateway include all tests for
@@ -166,6 +167,38 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
         $result = $saveHandler->destroy($id);
 
         $this->assertTrue($result);
+    }
+    
+    public function testExpiredSessionDoesNotCauseARecursion()
+    {
+        // puts an expired session in the db
+        $query = "
+INSERT INTO `sessions` (
+    `{$this->options->getIdColumn()}`,
+    `{$this->options->getNameColumn()}`,
+    `{$this->options->getModifiedColumn()}`,
+    `{$this->options->getLifetimeColumn()}`,
+    `{$this->options->getDataColumn()}`
+) VALUES (
+    '123', 'zend-session-test', ".(time() - 31).", 30, 'foobar'
+);
+";
+        $this->adapter->query($query, Adapter::QUERY_MODE_EXECUTE);
+
+        $this->usedSaveHandlers[] = $saveHandler = new TestDbTableGatewaySaveHandler($this->tableGateway, $this->options);
+        $saveHandler->open('savepath', 'zend-session-test');
+
+        $this->assertSame(0, $saveHandler->getNumReadCalls());
+        $this->assertSame(0, $saveHandler->getNumDestroyCalls());
+
+        $success = (boolean) $saveHandler->read('123');
+        $this->assertFalse($success);
+
+        $this->assertSame(2, $saveHandler->getNumReadCalls());
+        $this->assertSame(1, $saveHandler->getNumDestroyCalls());
+
+        // cleans the test record from the db
+        $this->adapter->query("DELETE FROM `sessions` WHERE `{$this->options->getIdColumn()}` = '123';");
     }
 
     /**

--- a/test/TestAsset/TestDbTableGatewaySaveHandler.php
+++ b/test/TestAsset/TestDbTableGatewaySaveHandler.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Session\TestAsset;
+
+use Zend\Session\SaveHandler\DbTableGateway;
+
+class TestDbTableGatewaySaveHandler extends DbTableGateway
+{
+    protected $numReadCalls = 0;
+
+    protected $numDestroyCalls = 0;
+    
+    public function getNumReadCalls()
+    {
+        return $this->numReadCalls;
+    }
+    
+    public function getNumDestroyCalls()
+    {
+        return $this->numDestroyCalls;
+    }
+
+    public function read($id, $destroyExpired = true)
+    {
+        $this->numReadCalls++;
+        return parent::read($id, $destroyExpired);
+    }
+    
+    public function destroy($id)
+    {
+        $this->numDestroyCalls++;
+        return parent::destroy($id);
+    }
+}


### PR DESCRIPTION
I am having an issue where my app reaches the memory limit whenever a session expires. I've tracked down the problem to a recursion in this component. 

This PR contains a simple fix.
