### PR TITLE
Fix the configuration key in the documentation 

### DIFF
--- a/doc/book/manager.md
+++ b/doc/book/manager.md
@@ -29,7 +29,7 @@ options in your local or global config:
 use Zend\Session;
 
 return [
-    'session' => [
+    'session_manager' => [
         'config' => [
             'class' => Session\Config\SessionConfig::class,
             'options' => [


### PR DESCRIPTION
… from 'session' to 'session_config'

The documentation is inconsistent:
- [initializing-the-session-manager](https://docs.zendframework.com/zend-session/manager/#initializing-the-session-manager) says the configuration key is named "session"
- [Session-Config > Service Manager Factory](https://docs.zendframework.com/zend-session/config/#session-config_1) says the configuration key is named "session_config".
- [SessionConfigFactory](https://github.com/zendframework/zend-session/blob/master/src/Service/SessionConfigFactory.php#L39) actually uses "session_config".

Using the wrong config key "session" leads to this error message: 

```
Configuration is missing a "session_config" key, or the value of that key is not an array
```

This PR replaces the (wrong) configuration key "session" with the correct "session_config".

_EDIT:_ The above is wrong, actually this is the configuration for the Session Manager (and not the configuration!). The correct key for this would be "session_manager" as seen here: [SessionManagerFactory](https://github.com/zendframework/zend-session/blob/master/src/Service/SessionManagerFactory.php#L112).
