### PR TITLE
SessionManager creates instance of $requestedName

### DIFF
--- a/src/Service/SessionManagerFactory.php
+++ b/src/Service/SessionManagerFactory.php
@@ -18,6 +18,7 @@ use Zend\Session\Container;
 use Zend\Session\SaveHandler\SaveHandlerInterface;
 use Zend\Session\SessionManager;
 use Zend\Session\Storage\StorageInterface;
+use Zend\Session\ManagerInterface;
 
 class SessionManagerFactory implements FactoryInterface
 {
@@ -124,7 +125,17 @@ class SessionManagerFactory implements FactoryInterface
             }
         }
 
-        $manager = new SessionManager($config, $storage, $saveHandler, $validators, $options);
+        if (!class_exists($requestedName)) {
+            $requestedName = SessionManager::class;
+        } elseif (!is_subclass_of($requestedName, ManagerInterface::class)) {
+            throw new ServiceNotCreatedException(sprintf(
+                'SessionManager requires that the %s service implement %s',
+                $requestedName,
+                ManagerInterface::class
+            ));
+        }
+
+        $manager = new $requestedName($config, $storage, $saveHandler, $validators, $options);
 
         // If configuration enables the session manager as the default manager for container
         // instances, do so.

--- a/test/Service/SessionManagerFactoryTest.php
+++ b/test/Service/SessionManagerFactoryTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Session\Service;
 use Zend\EventManager\Test\EventListenerIntrospectionTrait;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\Session\Config\ConfigInterface;
 use Zend\Session\Container;
 use Zend\Session\ManagerInterface;
@@ -21,6 +22,8 @@ use Zend\Session\SessionManager;
 use Zend\Session\Storage\ArrayStorage;
 use Zend\Session\Storage\StorageInterface;
 use Zend\Session\Validator;
+use ZendTest\Session\TestAsset\TestManager;
+use ZendTest\Session\TestAsset\TestSaveHandler;
 
 /**
  * @group      Zend_Session
@@ -35,6 +38,8 @@ class SessionManagerFactoryTest extends \PHPUnit_Framework_TestCase
         $config = new Config([
             'factories' => [
                 ManagerInterface::class => SessionManagerFactory::class,
+                TestManager::class => SessionManagerFactory::class,
+                TestSaveHandler::class => SessionManagerFactory::class,
             ],
         ]);
         $this->services = new ServiceManager();
@@ -207,5 +212,17 @@ class SessionManagerFactoryTest extends \PHPUnit_Framework_TestCase
 
         $manager = $this->services->get(ManagerInterface::class);
         $this->assertAttributeSame([], 'validators', $manager);
+    }
+
+    public function testFactorySupportsExtendedSessionManager()
+    {
+        $manager = $this->services->get(TestManager::class);
+        $this->assertInstanceOf(TestManager::class, $manager);
+    }
+
+    public function testFactoryRaisesServiceNotCreatedException()
+    {
+        $this->setExpectedException(ServiceNotCreatedException::class);
+        $manager = $this->services->get(TestSaveHandler::class);
     }
 }


### PR DESCRIPTION
In order to extend the behaviour and functionality of the (default) `SessionManager` in an application, one still wants to use the default factory with all its logic reading config and setting up the manager.

This isn't possible if the class instantiated by the factory is hard-coded. This PR wants to solve this  by considering the `$requestedName` parameter when creating a `SessionManager` instance. With a simple alias one can now create extended session managers.