### PR TITLE
Removed slack integration in travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,3 @@ after_script:
 
 notifications:
   email: false
-  slack:
-    rooms:
-      - secure:  "MlhbWQ2bxDu9dmQ7o2v/WwwAedl57SVVew0XN/Wvbnt1Q8DY+kBGVxmV7DzurOG0iiq7pzYySNgdyqKpE/2g1IhWD7txrT9BCSq0xPk4i+AUn4xMViZKCVkPYhaFo9K3Z1HnPJPfcnDz075umGKWhfip12LSIMkXRqkNANgKLZ3ouDFRRG1NL7bOmW8GDIAcF3TpIDCy9L+awnGMHTtSO6M1jtueksQpBH7ESosrtkferzNVeV2USvzZbzI04PQ9vsrOOZnkqXgNsk3+gMvZNw6PbCk3eOmgGyFaygpL1NXi3VV6sK6SFtwiuwAiEhiFudOnovpE/90HKtWyCISSSGMlUHF6trEVGR0tQxuw+Du1HNrBhiWZHj6vdMpNdZSEqwBEbCeO5LAHM9fKDIT2utQQXrk62julZCvnAupImgBl5IswlO6f/cGv8/cesLulyc9t6L0LCuuXG2xK/WPSCOtkFB4nuOgNNNXhkljyrYxi8poXGa+4SupqCMA0iNPeUB6NnyCMrBCbUnjEjNIGMezx7ELIoepJuw66py6smigYGyrVXhodlGPvr7jaXVjYHNbDadHA55Vk6tRgYwTZclnrSn8sU3jI3xW/a6APkwQMd40yc+GAy5F72jpONiXeB7f8UG+d4qoWH4doBJii+cb/tVroH1tFDlfTSa5XRec="
-    on_success: change
-    on_failure: always


### PR DESCRIPTION
Current integration is done by `zendframework/zfbot`.