### PR TITLE
[Doc]Added notice about removed options in PHP 7.1

### DIFF
--- a/doc/book/config.md
+++ b/doc/book/config.md
@@ -23,12 +23,12 @@ Option                    | Data Type | Description
 `cookie_lifetime`         | `integer` | Specifies the lifetime of the cookie in seconds which is sent to the browser.
 `cookie_path`             | `string`  | Specifies path to set in the session cookie.
 `cookie_secure`           | `boolean` | Specifies whether cookies should only be sent over secure connections.
-`entropy_length`          | `integer` | Specifies the number of bytes which will be read from the file specified in entropy_file.
-`entropy_file`            | `string`  | Defines a path to an external resource (file) which will be used as an additional entropy.
+`entropy_length`          | `integer` | Specifies the number of bytes which will be read from the file specified in entropy_file. Removed in PHP 7.1.0.
+`entropy_file`            | `string`  | Defines a path to an external resource (file) which will be used as an additional entropy. Removed in PHP 7.1.0.
 `gc_maxlifetime`          | `integer` | Specifies the number of seconds after which data will be seen as ‘garbage’.
 `gc_divisor`              | `integer` | Defines the probability that the gc process is started on every session initialization.
 `gc_probability`          | `integer` | Defines the probability that the gc process is started on every session initialization.
-`hash_bits_per_character` | `integer` | Defines how many bits are stored in each character when converting the binary hash data.
+`hash_bits_per_character` | `integer` | Defines how many bits are stored in each character when converting the binary hash data. Removed in PHP 7.1.0.
 `name`                    | `string`  | Specifies the name of the session which is used as cookie name.
 `remember_me_seconds`     | `integer` | Specifies how long to remember the session before clearing data.
 `save_path`               | `string`  | Defines the argument which is passed to the save handler.

--- a/doc/book/config.md
+++ b/doc/book/config.md
@@ -28,6 +28,7 @@ Option                    | Data Type | Description
 `gc_maxlifetime`          | `integer` | Specifies the number of seconds after which data will be seen as ‘garbage’.
 `gc_divisor`              | `integer` | Defines the probability that the gc process is started on every session initialization.
 `gc_probability`          | `integer` | Defines the probability that the gc process is started on every session initialization.
+`hash_function`           | `integer` | Defines which built-in hash algorithm is used. Removed in PHP 7.1.0.
 `hash_bits_per_character` | `integer` | Defines how many bits are stored in each character when converting the binary hash data. Removed in PHP 7.1.0.
 `name`                    | `string`  | Specifies the name of the session which is used as cookie name.
 `remember_me_seconds`     | `integer` | Specifies how long to remember the session before clearing data.


### PR DESCRIPTION
The options  `entropy_length`, `entropy_file`, `hash_function` and `hash_bits_per_charachter` was removed in PHP 7.1 and when they are set, an exception is thrown.
But this is not reflected in the documentation.