### PR TITLE
Don’t pass Traversable as ArrayUtils::merge parameter

### DIFF
--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -126,17 +126,17 @@ class SessionManager extends AbstractManager
         $oldSessionData = [];
         if (isset($_SESSION)) {
             $oldSessionData = $_SESSION;
+
+            // convert session data to plain array that’ll be acceptable as
+            // ArrayUtils::merge parameter
+            if ($oldSessionData instanceof Storage\StorageInterface) {
+                $oldSessionData = $oldSessionData->toArray();
+            } elseif ($oldSessionData instanceof \Traversable) {
+                $oldSessionData = iterator_to_array($oldSessionData);
+            }
         }
 
         session_start();
-
-        // convert session data to plain array that’ll be acceptable as
-        // ArrayUtils::merge parameter
-        if ($oldSessionData instanceof Storage\StorageInterface) {
-            $oldSessionData = $oldSessionData->toArray();
-        } elseif ($oldSessionData instanceof \Traversable) {
-            $oldSessionData = iterator_to_array($oldSessionData);
-        }
 
         if (! empty($oldSessionData) && is_array($oldSessionData)) {
             $_SESSION = ArrayUtils::merge($oldSessionData, $_SESSION, true);

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -130,9 +130,13 @@ class SessionManager extends AbstractManager
 
         session_start();
 
-        if ($oldSessionData instanceof \Traversable
-            || (! empty($oldSessionData) && is_array($oldSessionData))
-        ) {
+        if ($oldSessionData instanceof Storage\StorageInterface) {
+            // convert session data to plain array that’ll be acceptable as
+            // ArrayUtils::merge parameter
+            $oldSessionData = $oldSessionData->toArray();
+        }
+
+        if (! empty($oldSessionData) && is_array($oldSessionData)) {
             $_SESSION = ArrayUtils::merge($oldSessionData, $_SESSION, true);
         }
 

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -130,10 +130,12 @@ class SessionManager extends AbstractManager
 
         session_start();
 
+        // convert session data to plain array that’ll be acceptable as
+        // ArrayUtils::merge parameter
         if ($oldSessionData instanceof Storage\StorageInterface) {
-            // convert session data to plain array that’ll be acceptable as
-            // ArrayUtils::merge parameter
             $oldSessionData = $oldSessionData->toArray();
+        } elseif ($oldSessionData instanceof \Traversable) {
+            $oldSessionData = iterator_to_array($oldSessionData);
         }
 
         if (! empty($oldSessionData) && is_array($oldSessionData)) {

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -18,6 +18,7 @@ use Zend\Session\Exception\RuntimeException;
 use Zend\Session\SessionManager;
 use Zend\Session\Storage\ArrayStorage;
 use Zend\Session\Storage\SessionArrayStorage;
+use Zend\Session\Storage\StorageInterface;
 use Zend\Session\Validator\Id;
 use Zend\Session\Validator\RemoteAddr;
 
@@ -217,6 +218,17 @@ class SessionManagerTest extends TestCase
         $id2 = session_id();
         $this->assertTrue($this->manager->sessionExists());
         $this->assertNotEquals($id1, $id2);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testStartConvertsSessionDataToArrayBeforeMerging()
+    {
+        $sessionStorage = $this->prophesize(StorageInterface::class);
+        $_SESSION = $sessionStorage->reveal();
+        $sessionStorage->toArray()->shouldBeCalledTimes(1)->willReturn([]);
+        $this->manager->start();
     }
 
     /**

--- a/test/SessionManagerTest.php
+++ b/test/SessionManagerTest.php
@@ -223,12 +223,31 @@ class SessionManagerTest extends TestCase
     /**
      * @runInSeparateProcess
      */
-    public function testStartConvertsSessionDataToArrayBeforeMerging()
+    public function testStartConvertsSessionDataFromStorageInterfaceToArrayBeforeMerging()
     {
+        $key = 'testData';
+        $data = [$key => 'test'];
         $sessionStorage = $this->prophesize(StorageInterface::class);
         $_SESSION = $sessionStorage->reveal();
-        $sessionStorage->toArray()->shouldBeCalledTimes(1)->willReturn([]);
+        $sessionStorage->toArray()->shouldBeCalledTimes(1)->willReturn($data);
         $this->manager->start();
+        $this->assertInternalType('array', $_SESSION);
+        $this->assertArrayHasKey($key, $_SESSION);
+        $this->assertSame($data[$key], $_SESSION[$key]);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testStartConvertsSessionDataFromTraversableToArrayBeforeMerging()
+    {
+        $key = 'testData';
+        $data = [$key => 'test'];
+        $_SESSION = new \ArrayIterator($data);
+        $this->manager->start();
+        $this->assertInternalType('array', $_SESSION);
+        $this->assertArrayHasKey($key, $_SESSION);
+        $this->assertSame($data[$key], $_SESSION[$key]);
     }
 
     /**


### PR DESCRIPTION
`SessionManager::start()` retrieves data from `$_SESSION` and passes it to `ArrayUtils::merge()`. The problem is that the retrieved data can be either:

* plain `array` — that’s not a problem :slightly_smiling_face:;
* or `Traversable` (specifically, it should be instance of `Zend\Session\Storage\StorageInterface`), but such type is not acceptable as `ArrayUtils::merge()` parameter :disappointed:.

The point of this PR is to convert such `Traversable` to a plain `array`, by calling `toArray()` (defined in the mentioned `StorageInterface`) on it. I’ve created also an alternative PR in `zend-stdlib` (zendframework/zend-stdlib#86) that’d let `ArrayUtils::merge()` accept `iterable` parameters.