### PR TITLE
Allow using any configured save handler extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
+        - LEGACY_DEPS="phpunit/phpunit php-mock/php-mock-phpunit"
     - php: 5.6
       env:
         - DEPS=latest

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require-dev": {
         "container-interop/container-interop": "^1.1",
         "mongodb/mongodb": "^1.0.1",
+        "php-mock/php-mock-phpunit": "^1.1.2 || ^2.0",
         "phpunit/phpunit": "^5.7.15 || ^6.0.8",
         "zendframework/zend-cache": "^2.6.1",
         "zendframework/zend-coding-standard": "~1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "db84a752e05be479fc690b8297c819b2",
+    "content-hash": "097d88139a812af12fd8e367091f80d1",
     "packages": [
         {
             "name": "zendframework/zend-eventmanager",
@@ -393,6 +393,171 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "php-mock/php-mock",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mock/php-mock.git",
+                "reference": "22d297231118e6fd5b9db087fbe1ef866c2b95d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mock/php-mock/zipball/22d297231118e6fd5b9db087fbe1ef866c2b95d2",
+                "reference": "22d297231118e6fd5b9db087fbe1ef866c2b95d2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/php-text-template": "^1"
+            },
+            "replace": {
+                "malkusch/php-mock": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7"
+            },
+            "suggest": {
+                "php-mock/php-mock-phpunit": "Allows integration into PHPUnit testcase with the trait PHPMock."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpmock\\": [
+                        "classes/",
+                        "tests/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Malkusch",
+                    "email": "markus@malkusch.de",
+                    "homepage": "http://markus.malkusch.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP-Mock can mock built-in PHP functions (e.g. time()). PHP-Mock relies on PHP's namespace fallback policy. No further extension is needed.",
+            "homepage": "https://github.com/php-mock/php-mock",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "function",
+                "mock",
+                "stub",
+                "test",
+                "test double"
+            ],
+            "time": "2017-02-17T20:52:52+00:00"
+        },
+        {
+            "name": "php-mock/php-mock-integration",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mock/php-mock-integration.git",
+                "reference": "5a0d7d7755f823bc2a230cfa45058b40f9013bc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mock/php-mock-integration/zipball/5a0d7d7755f823bc2a230cfa45058b40f9013bc4",
+                "reference": "5a0d7d7755f823bc2a230cfa45058b40f9013bc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "php-mock/php-mock": "^2",
+                "phpunit/php-text-template": "^1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpmock\\integration\\": "classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Malkusch",
+                    "email": "markus@malkusch.de",
+                    "homepage": "http://markus.malkusch.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Integration package for PHP-Mock",
+            "homepage": "https://github.com/php-mock/php-mock-integration",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "function",
+                "mock",
+                "stub",
+                "test",
+                "test double"
+            ],
+            "time": "2017-02-17T21:31:34+00:00"
+        },
+        {
+            "name": "php-mock/php-mock-phpunit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mock/php-mock-phpunit.git",
+                "reference": "173781abdc632c59200253e12e2b991ae6a4574f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mock/php-mock-phpunit/zipball/173781abdc632c59200253e12e2b991ae6a4574f",
+                "reference": "173781abdc632c59200253e12e2b991ae6a4574f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7",
+                "php-mock/php-mock-integration": "^2",
+                "phpunit/phpunit": "^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpmock\\phpunit\\": "classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Malkusch",
+                    "email": "markus@malkusch.de",
+                    "homepage": "http://markus.malkusch.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mock built-in PHP functions (e.g. time()) with PHPUnit. This package relies on PHP's namespace fallback policy. No further extension is needed.",
+            "homepage": "https://github.com/php-mock/php-mock-phpunit",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "function",
+                "mock",
+                "phpunit",
+                "stub",
+                "test",
+                "test double"
+            ],
+            "time": "2017-02-17T22:44:38+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Session\Config;
 
+use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use SessionHandlerInterface;
@@ -23,6 +24,8 @@ use ZendTest\Session\TestAsset\TestSaveHandler;
  */
 class SessionConfigTest extends TestCase
 {
+    use PHPMock;
+
     /**
      * @var SessionConfig
      */
@@ -1186,5 +1189,21 @@ class SessionConfigTest extends TestCase
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('("stdClass"); must implement SessionHandlerInterface');
         $this->config->setPhpSaveHandler($handler);
+    }
+
+    public function testProvidingValidKnownSessionHandlerToSetPhpSaveHandlerResultsInNoErrors()
+    {
+        $phpinfo = $this->getFunctionMock('Zend\Session\Config', 'phpinfo');
+        $phpinfo
+            ->expects($this->once())
+            ->will($this->returnCallback(function () {
+                echo "Registered save handlers => user files unittest";
+            }));
+
+        $sessionModuleName = $this->getFunctionMock('Zend\Session\Config', 'session_module_name');
+        $sessionModuleName->expects($this->once());
+
+        $this->assertSame($this->config, $this->config->setPhpSaveHandler('unittest'));
+        $this->assertEquals('unittest', $this->config->getOption('save_handler'));
     }
 }


### PR DESCRIPTION
Per #97, the fix in 2.8.1 (provided by #92) for having `SessionConfig::setPhpSaveHandler()` work with PHP 7.2 was too aggressive, and prevented the ability to set the value to a known extension, such as redis.

This patch fixes that approach by grabbing a list of known save handlers from `phpinfo()` (after first stripping `user` from the list), and comparing the incoming value to that list; if it is in that list, it now uses `session_module_name()` to set the value.

Tests for this are next to impossible to write, unfortunately, as we would need to have multiple extensions installed on developer machines and in Travis. I have instead added tests verifying the various exceptions thrown, including one thrown when a value is in the known PHP save handlers list, but fails to be set properly.

Fixes #97.