### PR TITLE
Provide negative unit-test for Issue #81

### DIFF
--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -53,6 +53,11 @@ abstract class AbstractContainer extends ArrayObject
     protected static $defaultManager;
 
     /**
+     * Default value to return by reference from offsetGet
+     */
+    private $defaultValue = null;
+
+    /**
      * Constructor
      *
      * Provide a name ('Default' if none provided) and a ManagerInterface instance.
@@ -425,7 +430,7 @@ abstract class AbstractContainer extends ArrayObject
     public function &offsetGet($key)
     {
         if (! $this->offsetExists($key)) {
-            return;
+            return $this->defaultValue;
         }
         $storage = $this->getStorage();
         $name = $this->getName();

--- a/test/AbstractContainerTest.php
+++ b/test/AbstractContainerTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Session;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Session\Container;
+use Zend\Session\Config\StandardConfig;
+use Zend\Session\ManagerInterface as Manager;
+use ZendTest\Session\TestAsset\TestContainer;
+
+/**
+ * @group      Zend_Session
+ * @covers Zend\Session\AbstractContainer
+ */
+class AbstractContainerTest extends TestCase
+{
+    /**
+     * Hack to allow running tests in separate processes
+     *
+     * @see    http://matthewturland.com/2010/08/19/process-isolation-in-phpunit/
+     */
+    protected $preserveGlobalState = false;
+
+    /**
+     * @var Manager
+     */
+    protected $manager;
+
+    /**
+     * @var Container
+     */
+    protected $container;
+
+    public function setUp()
+    {
+        $_SESSION = [];
+        Container::setDefaultManager(null);
+
+        $config = new StandardConfig([
+            'storage' => 'Zend\\Session\\Storage\\ArrayStorage',
+        ]);
+
+        $this->manager = $manager = new TestAsset\TestManager($config);
+        $this->container = new TestContainer('Default', $manager);
+    }
+
+    public function tearDown()
+    {
+        $_SESSION = [];
+        Container::setDefaultManager(null);
+    }
+
+    /**
+     * This test case fails on zend-session 2.8.0 with the php error below and works fine on 2.7.*.
+     * "Only variable references should be returned by reference"
+     */
+    public function testOffsetGetMissingKey()
+    {
+        self::assertNull($this->container->offsetGet('this key does not exist in the container'));
+    }
+}

--- a/test/TestAsset/TestContainer.php
+++ b/test/TestAsset/TestContainer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Session\TestAsset;
+
+use Zend\Session\AbstractContainer;
+
+class TestContainer extends AbstractContainer
+{
+    // do nothing
+}


### PR DESCRIPTION
Creates a testcase for retrieving a value of a non-existing key from the AbstractContainer. 

This worked in 2.7.x, but fails on 2.8.0.