### PR TITLE
Fix for issue #84 Garbage set wrong way. GcMaxlifetime (session.gc_ma…

### DIFF
--- a/src/SaveHandler/MongoDB.php
+++ b/src/SaveHandler/MongoDB.php
@@ -219,7 +219,7 @@ class MongoDB implements SaveHandlerInterface
          * each document. Doing so would require a $where query to work with the
          * computed value (modified + lifetime) and be very inefficient.
          */
-        $microseconds = floor(microtime(true) * 1000) - $maxlifetime;
+        $microseconds = floor(microtime(true) * 1000) - $maxlifetime * 1000;
 
         $result = $this->mongoCollection->deleteMany(
             [

--- a/test/SaveHandler/MongoDBTest.php
+++ b/test/SaveHandler/MongoDBTest.php
@@ -136,6 +136,26 @@ class MongoDBTest extends TestCase
         $this->assertEquals(0, $this->mongoCollection->count());
     }
 
+    public function testGarbageCollectionMaxlifetimeIsInSeconds()
+    {
+        $saveHandler = new MongoDB($this->mongoClient, $this->options);
+        $this->assertTrue($saveHandler->open('savepath', 'sessionname'));
+
+        $data = ['foo' => 'bar'];
+
+        $this->assertTrue($saveHandler->write(123, serialize($data)));
+        sleep(1);
+        $this->assertTrue($saveHandler->write(456, serialize($data)));
+        $this->assertEquals(2, $this->mongoCollection->count());
+
+        // Clear everything what is at least 1 second old.
+        $saveHandler->gc(1);
+        $this->assertEquals(1, $this->mongoCollection->count());
+
+        $this->assertEmpty($saveHandler->read(123));
+        $this->assertNotEmpty($saveHandler->read(456));
+    }
+
     /**
      * @expectedException \MongoDB\Driver\Exception\RuntimeException
      */


### PR DESCRIPTION
…xlifetime) configuration is set in seconds, so the value must be adjusted in the microseconds calculation.

Fixes #84