### PR TITLE
Fix #104: php 7.2 handle ini_set() when session already started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- [#107](https://github.com/zendframework/zend-session/pull/107) fix error `ini_set()` can't be called when session is active.
+- [#107](https://github.com/zendframework/zend-session/pull/107) fix error `ini_set()` can't be called when session is active at PHP 7.2 environment.
 
 ## 2.8.3 - 2017-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#107](https://github.com/zendframework/zend-session/pull/107) fix error `ini_set()` can't be called when session is active.
 
 ## 2.8.3 - 2017-12-01
 

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -133,6 +133,11 @@ class SessionConfig extends StandardConfig
                 break;
         }
 
+        $iniGet = ini_get($key);
+        if ($iniGet && (string) $iniGet === (string) $storageValue) {
+            return $this;
+        }
+
         $sessionRequiresRestart = false;
         if (session_status() == PHP_SESSION_ACTIVE) {
             session_write_close();

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -133,8 +133,9 @@ class SessionConfig extends StandardConfig
                 break;
         }
 
-        $iniGet = ini_get($key);
-        if ($iniGet && (string) $iniGet === (string) $storageValue) {
+        $iniGet       = ini_get($key);
+        $storageValue = (string) $storageValue;
+        if ($iniGet && (string) $iniGet === $storageValue) {
             return $this;
         }
 
@@ -144,7 +145,7 @@ class SessionConfig extends StandardConfig
             $sessionRequiresRestart = true;
         }
 
-        $result = ini_set($key, (string) $storageValue);
+        $result = ini_set($key, $storageValue);
 
         if ($sessionRequiresRestart) {
             session_start();

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -133,7 +133,18 @@ class SessionConfig extends StandardConfig
                 break;
         }
 
+        $sessionAlreadyStarted = false;
+        if (session_status() == PHP_SESSION_ACTIVE) {
+            $sessionAlreadyStarted = true;
+            session_write_close();
+        }
+
         $result = ini_set($key, (string) $storageValue);
+
+        if (session_status() !== PHP_SESSION_ACTIVE && $sessionAlreadyStarted) {
+            session_start();
+        }
+
         if (false === $result) {
             throw new Exception\InvalidArgumentException(
                 "'{$key}' is not a valid sessions-related ini setting."

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -141,7 +141,7 @@ class SessionConfig extends StandardConfig
 
         $result = ini_set($key, (string) $storageValue);
 
-        if (session_status() !== PHP_SESSION_ACTIVE && $sessionRequiresRestart) {
+        if ($sessionRequiresRestart) {
             session_start();
         }
 

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -133,15 +133,15 @@ class SessionConfig extends StandardConfig
                 break;
         }
 
-        $sessionAlreadyStarted = false;
+        $sessionRequiresRestart = false;
         if (session_status() == PHP_SESSION_ACTIVE) {
-            $sessionAlreadyStarted = true;
+            $sessionRequiresRestart = true;
             session_write_close();
         }
 
         $result = ini_set($key, (string) $storageValue);
 
-        if (session_status() !== PHP_SESSION_ACTIVE && $sessionAlreadyStarted) {
+        if (session_status() !== PHP_SESSION_ACTIVE && $sessionRequiresRestart) {
             session_start();
         }
 

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -135,8 +135,8 @@ class SessionConfig extends StandardConfig
 
         $sessionRequiresRestart = false;
         if (session_status() == PHP_SESSION_ACTIVE) {
-            $sessionRequiresRestart = true;
             session_write_close();
+            $sessionRequiresRestart = true;
         }
 
         $result = ini_set($key, (string) $storageValue);

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -135,7 +135,7 @@ class SessionConfig extends StandardConfig
 
         $iniGet       = ini_get($key);
         $storageValue = (string) $storageValue;
-        if ($iniGet && (string) $iniGet === $storageValue) {
+        if (false !== $iniGet && (string) $iniGet === $storageValue) {
             return $this;
         }
 

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -104,11 +104,11 @@ class SessionConfigTest extends TestCase
         $this->assertEquals('FOOBAR', ini_get('session.name'));
     }
 
-    public function testIdempotentNameAltersIniSettingAfterSessionStart()
+    public function testIdempotentNameAltersIniSettingWithSameValueAfterSessionStart()
     {
+        $this->config->setName('FOOBAR');
         session_start();
 
-        $this->config->setName('FOOBAR');
         $this->config->setName('FOOBAR');
         $this->assertEquals('FOOBAR', ini_get('session.name'));
     }

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -104,6 +104,15 @@ class SessionConfigTest extends TestCase
         $this->assertEquals('FOOBAR', ini_get('session.name'));
     }
 
+    public function testIdempotentNameAltersIniSettingAfterSessionStart()
+    {
+        session_start();
+
+        $this->config->setName('FOOBAR');
+        $this->config->setName('FOOBAR');
+        $this->assertEquals('FOOBAR', ini_get('session.name'));
+    }
+
     // session.save_handler
 
     public function testSaveHandlerDefaultsToIniSettings()

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -96,6 +96,14 @@ class SessionConfigTest extends TestCase
         $this->assertEquals('FOOBAR', ini_get('session.name'));
     }
 
+    public function testNameAltersIniSettingAfterSessionStart()
+    {
+        session_start();
+
+        $this->config->setName('FOOBAR');
+        $this->assertEquals('FOOBAR', ini_get('session.name'));
+    }
+
     // session.save_handler
 
     public function testSaveHandlerDefaultsToIniSettings()


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
          We can't call `ini_set()` when session already started
  - [x] Detail the original, incorrect behavior.
          When it called, it got error : "ini_set(): A session is active. You cannot change the session module's ini settings at this time"
  - [x] Detail the new, expected behavior.
          It call `session_write_close()` first, then start the session again 
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.