### PR TITLE
Allow PHPunit 6.5+ when zend-session gets installed as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,16 +24,13 @@
         "container-interop/container-interop": "^1.1",
         "mongodb/mongodb": "^1.0.1",
         "php-mock/php-mock-phpunit": "^1.1.2 || ^2.0",
-        "phpunit/phpunit": "^5.7.5 || ^6.0.13",
+        "phpunit/phpunit": "^5.7.5 || >=6.0.13 <6.5.0",
         "zendframework/zend-cache": "^2.6.1",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-db": "^2.7",
         "zendframework/zend-http": "^2.5.4",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-validator": "^2.6"
-    },
-    "conflict": {
-        "phpunit/phpunit": ">=6.5.0"
     },
     "suggest": {
         "mongodb/mongodb": "If you want to use the MongoDB session save handler",


### PR DESCRIPTION
https://github.com/zendframework/zend-session/commit/c323a94c0546d1bb33706c5d063180d048204bce introduced a `conflict` to the composer.json in order for builds to work. Unfortunately due to the nature of `conflict` this resulted in people not being able install phpunit >=6.5.0 when zend-session is being installed as dependency in a project.
I therefore propose to update the `require-dev` line for phpunit to define a version range which will still ensure that travis builds of zend-session won't install any phpunit version >=6.5.0 and simultanously allows users that require zend-session as dependency in their projects to use newer versions.