### PR TITLE
performSaveHandlerUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.8.6 - TBD
+## 2.8.7 - TBD
 
 ### Added
 
@@ -23,6 +23,29 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Fixed
 
 - Nothing.
+
+## 2.8.6 - 2019-08-10
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#118](https://github.com/zendframework/zend-session/pull/118) avoid unnecessary phpinfo() call
+   when register own save handler which is an object.
 
 ## 2.8.5 - 2018-02-22
 

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -466,10 +466,7 @@ class SessionConfig extends StandardConfig
                 return $phpSaveHandler;
             }
 
-            if ((! class_exists($phpSaveHandler)
-                    || ! (in_array(SessionHandlerInterface::class, class_implements($phpSaveHandler)))
-                )
-            ) {
+            if (! class_exists($phpSaveHandler) || !$phpSaveHandler instanceof SessionHandlerInterface) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Invalid save handler specified ("%s"); must be one of [%s]'
                     . ' or a class implementing %s',

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -467,7 +467,7 @@ class SessionConfig extends StandardConfig
             }
 
             if (! class_exists($phpSaveHandler)
-                    || ! is_a($phpSaveHandler, SessionHandlerInterface::class)
+                    || ! (in_array(SessionHandlerInterface::class, class_implements($phpSaveHandler)))
 
             ) {
                 throw new Exception\InvalidArgumentException(sprintf(

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -465,9 +465,9 @@ class SessionConfig extends StandardConfig
 
                 return $phpSaveHandler;
             }
-
+            //(in_array(SessionHandlerInterface::class, class_implements($phpSaveHandler))
             if (! class_exists($phpSaveHandler)
-                    || ! (in_array(SessionHandlerInterface::class, class_implements($phpSaveHandler)))
+                    || ! is_a($phpSaveHandler, SessionHandlerInterface::class)
 
             ) {
                 throw new Exception\InvalidArgumentException(sprintf(

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -465,7 +465,7 @@ class SessionConfig extends StandardConfig
 
                 return $phpSaveHandler;
             }
-            //(in_array(SessionHandlerInterface::class, class_implements($phpSaveHandler))
+
             if (! class_exists($phpSaveHandler)
                     || ! is_a($phpSaveHandler, SessionHandlerInterface::class)
 

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -474,7 +474,6 @@ class SessionConfig extends StandardConfig
                     . ' or a class implementing %s',
                     $phpSaveHandler,
                     implode(', ', $knownHandlers),
-                    SessionHandlerInterface::class,
                     SessionHandlerInterface::class
                 ));
             }

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -467,8 +467,7 @@ class SessionConfig extends StandardConfig
             }
 
             if (! class_exists($phpSaveHandler)
-                    || ! (in_array(SessionHandlerInterface::class, class_implements($phpSaveHandler)))
-
+                || ! is_a($phpSaveHandler, SessionHandlerInterface::class, true)
             ) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Invalid save handler specified ("%s"); must be one of [%s]'

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -466,7 +466,10 @@ class SessionConfig extends StandardConfig
                 return $phpSaveHandler;
             }
 
-            if (! class_exists($phpSaveHandler) || !$phpSaveHandler instanceof SessionHandlerInterface) {
+            if (! class_exists($phpSaveHandler)
+                    || ! (in_array(SessionHandlerInterface::class, class_implements($phpSaveHandler)))
+
+            ) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Invalid save handler specified ("%s"); must be one of [%s]'
                     . ' or a class implementing %s',

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -16,6 +16,7 @@ use SessionHandlerInterface;
 use stdClass;
 use Zend\Session\Config\SessionConfig;
 use Zend\Session\Exception;
+use Zend\Session\SaveHandler\SaveHandlerInterface;
 use ZendTest\Session\TestAsset\TestSaveHandler;
 
 /**
@@ -1244,5 +1245,15 @@ class SessionConfigTest extends TestCase
         $this->config->setOption('save_path', $url);
 
         $this->assertSame($url, $this->config->getOption('save_path'));
+    }
+
+    public function testNotCallLocateRegisteredSaveHandlersMethodIfSessionHandlerInterfaceWasPassed()
+    {
+        $phpinfo = $this->getFunctionMock('Zend\Session\Config', 'phpinfo');
+        $phpinfo
+            ->expects($this->never());
+
+        $saveHandler = $this->createMock(SessionHandlerInterface::class);
+        $this->config->setPhpSaveHandler($saveHandler);
     }
 }

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -21,7 +21,7 @@ use ZendTest\Session\TestAsset\TestSaveHandler;
 
 /**
  * @runTestsInSeparateProcesses
- * @covers Zend\Session\Config\SessionConfig
+ * @covers \Zend\Session\Config\SessionConfig
  */
 class SessionConfigTest extends TestCase
 {
@@ -32,9 +32,14 @@ class SessionConfigTest extends TestCase
      */
     protected $config;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->config = new SessionConfig;
+    }
+
+    protected function tearDown()
+    {
+        $this->config = null;
     }
 
     public function assertPhpLessThan71($message = 'This test requires a PHP version less than 7.1.0')


### PR DESCRIPTION
- check with isString() before calling locateRegisteredSaveHandlers()
- fixed https://github.com/zendframework/zend-session/issues/117