### PR TITLE
Hotfix for issue "Commands out of sync" on Mysqli adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,13 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
+    - TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL=true
+    - TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL=true
 
 services:
   - mongodb
+  - mysql
+  - postgresql
 
 matrix:
   include:
@@ -59,8 +63,11 @@ matrix:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - pecl channel-update pecl.php.net
   - pecl -q upgrade mongodb
   - $(php -m | grep -q mongodb) || echo "extension=mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - psql -c 'create database zend_session_test;' -U postgres
+  - mysql -e 'CREATE DATABASE zend_session_test;'
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#120](https://github.com/zendframework/zend-session/pull/120) fixes issue
+  "Commands out of sync; you can't run this command now" with DbTableGateway
+  save handler while using Mysqli adapter.
 
 ## 2.8.5 - 2018-02-22
 
@@ -43,7 +45,6 @@ All notable changes to this project will be documented in this file, in reverse 
 - Nothing.
 
 ### Fixed
-
 
 - [#108](https://github.com/zendframework/zend-session/pull/108) fixes a dependency
   conflict in `composer.json` which prevented `phpunit/phpunit` 6.5 or newer from 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,5 +30,16 @@
              in order to work. -->
         <env name="TESTS_ZEND_OB_ENABLED" value="false" />
 
+        <env name="TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL" value="false" />
+        <env name="TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_HOSTNAME" value="localhost" />
+        <env name="TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_USERNAME" value="travis" />
+        <env name="TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_PASSWORD" value="" />
+        <env name="TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_DATABASE" value="zend_session_test" />
+
+        <env name="TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL" value="false" />
+        <env name="TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL_HOSTNAME" value="localhost" />
+        <env name="TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL_USERNAME" value="travis" />
+        <env name="TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL_PASSWORD" value="" />
+        <env name="TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL_DATABASE" value="zend_session_test" />
     </php>
 </phpunit>

--- a/src/SaveHandler/DbTableGateway.php
+++ b/src/SaveHandler/DbTableGateway.php
@@ -95,18 +95,17 @@ class DbTableGateway implements SaveHandlerInterface
      */
     public function read($id, $destroyExpired = true)
     {
-        $rows = $this->tableGateway->select([
+        $row = $this->tableGateway->select([
             $this->options->getIdColumn()   => $id,
             $this->options->getNameColumn() => $this->sessionName,
-        ]);
+        ])->current();
 
-        if ($row = $rows->current()) {
+        if ($row) {
             if ($row->{$this->options->getModifiedColumn()} +
                 $row->{$this->options->getLifetimeColumn()} > time()) {
                 return (string) $row->{$this->options->getDataColumn()};
             }
             if ($destroyExpired) {
-                $rows = null;
                 $this->destroy($id);
             }
         }

--- a/src/SaveHandler/DbTableGateway.php
+++ b/src/SaveHandler/DbTableGateway.php
@@ -129,9 +129,9 @@ class DbTableGateway implements SaveHandlerInterface
         $rows = $this->tableGateway->select([
             $this->options->getIdColumn()   => $id,
             $this->options->getNameColumn() => $this->sessionName,
-        ]);
+        ])->current();
 
-        if ($rows->current()) {
+        if ($rows) {
             return (bool) $this->tableGateway->update($data, [
                 $this->options->getIdColumn()   => $id,
                 $this->options->getNameColumn() => $this->sessionName,

--- a/src/SaveHandler/DbTableGateway.php
+++ b/src/SaveHandler/DbTableGateway.php
@@ -106,6 +106,7 @@ class DbTableGateway implements SaveHandlerInterface
                 return (string) $row->{$this->options->getDataColumn()};
             }
             if ($destroyExpired) {
+                $rows = null;
                 $this->destroy($id);
             }
         }

--- a/test/SaveHandler/DbTableGateway/MysqliAdapterTest.php
+++ b/test/SaveHandler/DbTableGateway/MysqliAdapterTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-session for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-session/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Session\SaveHandler\DbTableGateway;
+
+use Zend\Db\Adapter\Adapter;
+use Zend\Session\SaveHandler\DbTableGateway;
+use ZendTest\Session\SaveHandler\DbTableGatewayTest;
+
+class MysqliAdapterTest extends DbTableGatewayTest
+{
+    /**
+     * @return Adapter
+     */
+    protected function getAdapter()
+    {
+        if (! getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL')) {
+            $this->markTestSkipped(sprintf(
+                '%s tests with MySQL are disabled',
+                DbTableGateway::class
+            ));
+        }
+
+        if (! extension_loaded('mysqli')) {
+            $this->markTestSkipped(sprintf(
+                '%s tests with Mysqli adapter are not enabled due to missing Mysqli extension',
+                DbTableGateway::class
+            ));
+        }
+
+        return new Adapter([
+            'driver' => 'mysqli',
+            'host' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_HOSTNAME'),
+            'user' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_USERNAME'),
+            'password' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_PASSWORD'),
+            'dbname' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_DATABASE'),
+        ]);
+    }
+}

--- a/test/SaveHandler/DbTableGateway/PdoMysqlAdapterTest.php
+++ b/test/SaveHandler/DbTableGateway/PdoMysqlAdapterTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-session for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-session/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Session\SaveHandler\DbTableGateway;
+
+use Zend\Db\Adapter\Adapter;
+use Zend\Session\SaveHandler\DbTableGateway;
+use ZendTest\Session\SaveHandler\DbTableGatewayTest;
+
+class PdoMysqlAdapterTest extends DbTableGatewayTest
+{
+    /**
+     * @return Adapter
+     */
+    protected function getAdapter()
+    {
+        if (! getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL')) {
+            $this->markTestSkipped(sprintf(
+                '%s tests with MySQL are disabled',
+                DbTableGateway::class
+            ));
+        }
+
+        if (! extension_loaded('mysqli')) {
+            $this->markTestSkipped(sprintf(
+                '%s tests with PDO_Mysql adapter are not enabled due to missing PDO_Mysql extension',
+                DbTableGateway::class
+            ));
+        }
+
+        return new Adapter([
+            'driver' => 'pdo_mysql',
+            'host' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_HOSTNAME'),
+            'user' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_USERNAME'),
+            'password' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_PASSWORD'),
+            'dbname' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_MYSQL_DATABASE'),
+        ]);
+    }
+}

--- a/test/SaveHandler/DbTableGateway/PdoSqliteAdapterTest.php
+++ b/test/SaveHandler/DbTableGateway/PdoSqliteAdapterTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-session for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-session/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Session\SaveHandler\DbTableGateway;
+
+use Zend\Db\Adapter\Adapter;
+use Zend\Session\SaveHandler\DbTableGateway;
+use ZendTest\Session\SaveHandler\DbTableGatewayTest;
+
+class PdoSqliteAdapterTest extends DbTableGatewayTest
+{
+    /**
+     * @return Adapter
+     */
+    protected function getAdapter()
+    {
+        if (! extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped(sprintf(
+                '%s tests with PDO_Sqlite adapter are not enabled due to missing PDO_Sqlite extension',
+                DbTableGateway::class
+            ));
+        }
+
+        return new Adapter([
+            'driver' => 'pdo_sqlite',
+            'database' => ':memory:',
+        ]);
+    }
+}

--- a/test/SaveHandler/DbTableGateway/PgsqlAdapterTest.php
+++ b/test/SaveHandler/DbTableGateway/PgsqlAdapterTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-session for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-session/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Session\SaveHandler\DbTableGateway;
+
+use Zend\Db\Adapter\Adapter;
+use Zend\Session\SaveHandler\DbTableGateway;
+use ZendTest\Session\SaveHandler\DbTableGatewayTest;
+
+class PgsqlAdapterTest extends DbTableGatewayTest
+{
+    /**
+     * @return Adapter
+     */
+    protected function getAdapter()
+    {
+        if (! getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL')) {
+            $this->markTestSkipped(sprintf(
+                '%s tests with Pgsql adapter are disabled',
+                DbTableGateway::class
+            ));
+        }
+
+        if (! extension_loaded('mysqli')) {
+            $this->markTestSkipped(sprintf(
+                '%s tests with Pgsql adapter are not enabled due to missing Pgsql extension',
+                DbTableGateway::class
+            ));
+        }
+
+        return new Adapter([
+            'driver' => 'pgsql',
+            'host' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL_HOSTNAME'),
+            'user' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL_USERNAME'),
+            'password' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL_PASSWORD'),
+            'dbname' => getenv('TESTS_ZEND_SESSION_ADAPTER_DRIVER_PGSQL_DATABASE'),
+        ]);
+    }
+}

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -211,61 +211,6 @@ INSERT INTO `sessions` (
         $this->adapter->query("DELETE FROM `sessions` WHERE `{$this->options->getIdColumn()}` = '123';");
     }
 
-    public function testSssionDestroyWhenLifetimeExceeded()
-    {
-        $this->usedSaveHandlers[] = $saveHandler = new DbTableGateway($this->tableGateway, $this->options);
-        $saveHandler->open('savepath', 'sessionname');
-
-        $id = '345';
-
-        $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
-
-        // set lifetime to 0
-        $query = <<<EOD
-UPDATE `sessions`
-    SET `{$this->options->getLifetimeColumn()}` = 0
-WHERE
-    `{$this->options->getIdColumn()}` = {$id}
-    AND `{$this->options->getNameColumn()}` = 'sessionname'
-EOD;
-        $this->adapter->query($query, Adapter::QUERY_MODE_EXECUTE);
-
-        // check destroy session
-        $result = $saveHandler->read($id);
-        $this->assertEquals($result, '');
-
-        // cleans the test record from the db
-        $this->adapter->query("DELETE FROM `sessions` WHERE `{$this->options->getIdColumn()}` = {$id};");
-    }
-
-    /**
-     * Sets up the database connection and creates the table for session data
-     *
-     * @param  \Zend\Session\SaveHandler\DbTableGatewayOptions $options
-     * @return void
-     */
-    protected function setupDb(DbTableGatewayOptions $options)
-    {
-        $this->adapter = new Adapter([
-            'driver' => 'pdo_sqlite',
-            'database' => ':memory:',
-        ]);
-
-
-        $query = <<<EOD
-CREATE TABLE `sessions` (
-    `{$options->getIdColumn()}` text NOT NULL,
-    `{$options->getNameColumn()}` text NOT NULL,
-    `{$options->getModifiedColumn()}` int(11) default NULL,
-    `{$options->getLifetimeColumn()}` int(11) default NULL,
-    `{$options->getDataColumn()}` text,
-    PRIMARY KEY (`{$options->getIdColumn()}`, `{$options->getNameColumn()}`)
-);
-EOD;
-        $this->adapter->query($query, Adapter::QUERY_MODE_EXECUTE);
-        $this->tableGateway = new TableGateway('sessions', $this->adapter);
-    }
-
     /**
      * Drops the database table for session data
      *

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -24,7 +24,7 @@ use ZendTest\Session\TestAsset\TestDbTableGatewaySaveHandler;
  * @group      Zend_Db_Table
  * @covers Zend\Session\SaveHandler\DbTableGateway
  */
-class DbTableGatewayTest extends TestCase
+abstract class DbTableGatewayTest extends TestCase
 {
     /**
      * @var Adapter
@@ -57,17 +57,18 @@ class DbTableGatewayTest extends TestCase
     private $testArray;
 
     /**
+     * @return Adapter
+     */
+    abstract protected function getAdapter();
+
+    /**
      * Setup performed prior to each test method
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
-        if (! extension_loaded('pdo_sqlite')) {
-            $this->markTestSkipped(
-                'Zend\Session\SaveHandler\DbTableGateway tests are not enabled due to missing PDO_Sqlite extension'
-            );
-        }
+        $this->adapter = $this->getAdapter();
 
         $this->options = new DbTableGatewayOptions([
             'nameColumn' => 'name',
@@ -133,9 +134,10 @@ class DbTableGatewayTest extends TestCase
 
         $this->assertEquals($this->testArray, unserialize($saveHandler->read($id)));
 
-        $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
+        $updateData = $this->testArray + ['time' => microtime(true)];
+        $this->assertTrue($saveHandler->write($id, serialize($updateData)));
 
-        $this->assertEquals($this->testArray, unserialize($saveHandler->read($id)));
+        $this->assertEquals($updateData, unserialize($saveHandler->read($id)));
     }
 
     public function testReadShouldAlwaysReturnString()
@@ -180,12 +182,12 @@ class DbTableGatewayTest extends TestCase
     {
         // puts an expired session in the db
         $query = "
-INSERT INTO `sessions` (
-    `{$this->options->getIdColumn()}`,
-    `{$this->options->getNameColumn()}`,
-    `{$this->options->getModifiedColumn()}`,
-    `{$this->options->getLifetimeColumn()}`,
-    `{$this->options->getDataColumn()}`
+INSERT INTO sessions (
+    {$this->options->getIdColumn()},
+    {$this->options->getNameColumn()},
+    {$this->options->getModifiedColumn()},
+    {$this->options->getLifetimeColumn()},
+    {$this->options->getDataColumn()}
 ) VALUES (
     '123', 'zend-session-test', ".(time() - 31).", 30, 'foobar'
 );
@@ -208,7 +210,7 @@ INSERT INTO `sessions` (
         $this->assertSame(1, $saveHandler->getNumDestroyCalls());
 
         // cleans the test record from the db
-        $this->adapter->query("DELETE FROM `sessions` WHERE `{$this->options->getIdColumn()}` = '123';");
+        $this->adapter->query("DELETE FROM sessions WHERE {$this->options->getIdColumn()} = '123';");
     }
 
     /**
@@ -219,20 +221,14 @@ INSERT INTO `sessions` (
      */
     protected function setupDb(DbTableGatewayOptions $options)
     {
-        $this->adapter = new Adapter([
-            'driver' => 'pdo_sqlite',
-            'database' => ':memory:',
-        ]);
-
-
         $query = <<<EOD
-CREATE TABLE `sessions` (
-    `{$options->getIdColumn()}` text NOT NULL,
-    `{$options->getNameColumn()}` text NOT NULL,
-    `{$options->getModifiedColumn()}` int(11) default NULL,
-    `{$options->getLifetimeColumn()}` int(11) default NULL,
-    `{$options->getDataColumn()}` text,
-    PRIMARY KEY (`{$options->getIdColumn()}`, `{$options->getNameColumn()}`)
+CREATE TABLE sessions (
+    {$options->getIdColumn()} int NOT NULL,
+    {$options->getNameColumn()} varchar(255) NOT NULL,
+    {$options->getModifiedColumn()} int default NULL,
+    {$options->getLifetimeColumn()} int default NULL,
+    {$options->getDataColumn()} text,
+    PRIMARY KEY ({$options->getIdColumn()}, {$options->getNameColumn()})
 );
 EOD;
         $this->adapter->query($query, Adapter::QUERY_MODE_EXECUTE);

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -213,17 +213,23 @@ INSERT INTO `sessions` (
 
     public function testSssionDestroyWhenLifetimeExceeded()
     {
-        $lifeTime = ini_get('session.gc_maxlifetime');
-        ini_set('session.gc_maxlifetime', 0);
+        //$lifeTime = ini_get('session.gc_maxlifetime');
+        //ini_set('session.gc_maxlifetime', 0);
 
         $this->usedSaveHandlers[] = $saveHandler = new DbTableGateway($this->tableGateway, $this->options);
         $saveHandler->open('savepath', 'sessionname');
 
-        ini_set('session.gc_maxlifetime', $lifeTime);
-
+        //ini_set('session.gc_maxlifetime', $lifeTime);
         $id = '242';
 
         $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
+
+        $query = <<<EOD
+UPDATE `sessions`
+SET `{$this->options->getLifetimeColumn()}` = 0
+WHERE `{$this->options->getIdColumn()}` = {$id}
+EOD;
+        $this->adapter->query($query, Adapter::QUERY_MODE_EXECUTE);
 
         // check destroy session
         $result = $saveHandler->read($id);

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -213,19 +213,29 @@ INSERT INTO `sessions` (
 
     public function testReadDestroysExpiredSession()
     {
-        $oldMaxlifetime = ini_get('session.gc_maxlifetime');
-        ini_set('session.gc_maxlifetime', 0);
-
         $this->usedSaveHandlers[] = $saveHandler = new DbTableGateway($this->tableGateway, $this->options);
         $saveHandler->open('savepath', 'sessionname');
 
         $id = '345';
 
         $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
-        // check destroy session
-        $this->assertEquals('', $saveHandler->read($id));
 
-        ini_set('session.gc_maxlifetime', $oldMaxlifetime);
+        // set lifetime to 0
+        $query = <<<EOD
+UPDATE `sessions`
+    SET `{$this->options->getLifetimeColumn()}` = 0
+WHERE
+    `{$this->options->getIdColumn()}` = {$id}
+    AND `{$this->options->getNameColumn()}` = 'sessionname'
+EOD;
+        $this->adapter->query($query, Adapter::QUERY_MODE_EXECUTE);
+
+        // check destroy session
+        $result = $saveHandler->read($id);
+        $this->assertEquals($result, '');
+
+        // cleans the test record from the db
+        $this->adapter->query("DELETE FROM `sessions` WHERE `{$this->options->getIdColumn()}` = {$id};");
     }
 
     /**

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -211,6 +211,23 @@ INSERT INTO `sessions` (
         $this->adapter->query("DELETE FROM `sessions` WHERE `{$this->options->getIdColumn()}` = '123';");
     }
 
+    public function testSssionDestroyWhenLifetimeExceeded()
+    {
+        // set lifetime
+        ini_set('session.gc_maxlifetime', 0);
+
+        $this->usedSaveHandlers[] = $saveHandler = new DbTableGateway($this->tableGateway, $this->options);
+        $saveHandler->open('savepath', 'sessionname');
+
+        $id = '242';
+
+        $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
+
+        // check session destroy
+        $result = $saveHandler->read($id);
+        $this->assertEquals($result, '');
+    }
+
     /**
      * Sets up the database connection and creates the table for session data
      *

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -224,11 +224,11 @@ INSERT INTO sessions (
 
         // set lifetime to 0
         $query = <<<EOD
-UPDATE `sessions`
-    SET `{$this->options->getLifetimeColumn()}` = 0
+UPDATE sessions
+    SET {$this->options->getLifetimeColumn()} = 0
 WHERE
-    `{$this->options->getIdColumn()}` = {$id}
-    AND `{$this->options->getNameColumn()}` = 'sessionname'
+    {$this->options->getIdColumn()} = {$id}
+    AND {$this->options->getNameColumn()} = 'sessionname'
 EOD;
         $this->adapter->query($query, Adapter::QUERY_MODE_EXECUTE);
 
@@ -237,7 +237,7 @@ EOD;
         $this->assertEquals($result, '');
 
         // cleans the test record from the db
-        $this->adapter->query("DELETE FROM `sessions` WHERE `{$this->options->getIdColumn()}` = {$id};");
+        $this->adapter->query("DELETE FROM sessions WHERE {$this->options->getIdColumn()} = {$id};");
     }
 
     /**

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -211,6 +211,61 @@ INSERT INTO `sessions` (
         $this->adapter->query("DELETE FROM `sessions` WHERE `{$this->options->getIdColumn()}` = '123';");
     }
 
+    public function testSessionDestroyWhenLifetimeExceeded()
+    {
+        $this->usedSaveHandlers[] = $saveHandler = new DbTableGateway($this->tableGateway, $this->options);
+        $saveHandler->open('savepath', 'sessionname');
+
+        $id = '345';
+
+        $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
+
+        // set lifetime to 0
+        $query = <<<EOD
+UPDATE `sessions`
+    SET `{$this->options->getLifetimeColumn()}` = 0
+WHERE
+    `{$this->options->getIdColumn()}` = {$id}
+    AND `{$this->options->getNameColumn()}` = 'sessionname'
+EOD;
+        $this->adapter->query($query, Adapter::QUERY_MODE_EXECUTE);
+
+        // check destroy session
+        $result = $saveHandler->read($id);
+        $this->assertEquals($result, '');
+
+        // cleans the test record from the db
+        $this->adapter->query("DELETE FROM `sessions` WHERE `{$this->options->getIdColumn()}` = {$id};");
+    }
+
+    /**
+     * Sets up the database connection and creates the table for session data
+     *
+     * @param  \Zend\Session\SaveHandler\DbTableGatewayOptions $options
+     * @return void
+     */
+    protected function setupDb(DbTableGatewayOptions $options)
+    {
+        $this->adapter = new Adapter([
+            'driver' => 'pdo_sqlite',
+            'database' => ':memory:',
+        ]);
+
+
+        $query = <<<EOD
+CREATE TABLE `sessions` (
+    `{$options->getIdColumn()}` text NOT NULL,
+    `{$options->getNameColumn()}` text NOT NULL,
+    `{$options->getModifiedColumn()}` int(11) default NULL,
+    `{$options->getLifetimeColumn()}` int(11) default NULL,
+    `{$options->getDataColumn()}` text,
+    PRIMARY KEY (`{$options->getIdColumn()}`, `{$options->getNameColumn()}`)
+);
+EOD;
+        $this->adapter->query($query, Adapter::QUERY_MODE_EXECUTE);
+        $this->tableGateway = new TableGateway('sessions', $this->adapter);
+    }
+
     /**
      * Drops the database table for session data
      *

--- a/test/SaveHandler/DbTableGatewayTest.php
+++ b/test/SaveHandler/DbTableGatewayTest.php
@@ -213,17 +213,19 @@ INSERT INTO `sessions` (
 
     public function testSssionDestroyWhenLifetimeExceeded()
     {
-        // set lifetime
+        $lifeTime = ini_get('session.gc_maxlifetime');
         ini_set('session.gc_maxlifetime', 0);
 
         $this->usedSaveHandlers[] = $saveHandler = new DbTableGateway($this->tableGateway, $this->options);
         $saveHandler->open('savepath', 'sessionname');
 
+        ini_set('session.gc_maxlifetime', $lifeTime);
+
         $id = '242';
 
         $this->assertTrue($saveHandler->write($id, serialize($this->testArray)));
 
-        // check session destroy
+        // check destroy session
         $result = $saveHandler->read($id);
         $this->assertEquals($result, '');
     }


### PR DESCRIPTION
Follow up to PR #116 and #109

The problem "Commands out of sync; you can't run this command now" is observed only while using mysqli adapter. That's why test from #109 pass also without changes in code as in tests we are using only PDO_Sqlite.

In this PR I am adding tests with different adapters - PDO_Sqlite, PDO_Mysql, Mysqli and Pgsql.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.
