### PR TITLE
Fix incorrect check if $options['input'] was ArrayAccess.

### DIFF
--- a/src/Storage/Factory.php
+++ b/src/Storage/Factory.php
@@ -131,17 +131,17 @@ abstract class Factory
     {
         $input = null;
         if (isset($options['input'])) {
-            if (null !== $options['input']
-                && ! is_array($options['input'])
+            $input = $options['input'];
+            if (null !== $input
+                && ! is_array($input)
                 && ! $input instanceof ArrayAccess
             ) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     '%s expects the "input" option to be null, an array, or to implement ArrayAccess; received "%s"',
                     $type,
-                    (is_object($options['input']) ? get_class($options['input']) : gettype($options['input']))
+                    (is_object($input) ? get_class($input) : gettype($input))
                 ));
             }
-            $input = $options['input'];
         }
 
         return new $type($input);

--- a/test/Service/StorageFactoryTest.php
+++ b/test/Service/StorageFactoryTest.php
@@ -68,6 +68,16 @@ class StorageFactoryTest extends TestCase
                     ],
                 ],
             ], SessionArrayStorage::class],
+            'session-array-storage-arrayobject' => [[
+                'session_storage' => [
+                    'type' => 'SessionArrayStorage',
+                    'options' => [
+                        'input' => new \ArrayObject([
+                            'foo' => 'bar',
+                        ]),
+                    ],
+                ],
+            ], SessionArrayStorage::class],
             'session-array-storage-fqcn' => [[
                 'session_storage' => [
                     'type' => SessionArrayStorage::class,


### PR DESCRIPTION
Previously, $input was always null, and that should have checked
`$options['input']` instead. (for ` && ! $input instanceof ArrayAccess`)
Move the assignment to $input above the conditions.

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior. ArrayAccess was not allowed for SessionArrayStorage and an exception would be thrown
  - [x] Detail the new, expected behavior. ArrayAccess is now allowed for SessionArrayStorage
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
