### PR TITLE
Properly merge arrays of allowed hash algorithms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- Fix a bug preventing two hash functions in hash_algos() (md2 and md4) from being used in SessionConfig->setHashFunction
 
 ## 2.9.0 - 2019-09-20
 
@@ -130,7 +130,7 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Fixed
 
 - [#108](https://github.com/zendframework/zend-session/pull/108) fixes a dependency
-  conflict in `composer.json` which prevented `phpunit/phpunit` 6.5 or newer from 
+  conflict in `composer.json` which prevented `phpunit/phpunit` 6.5 or newer from
   being installed together with `zendframework/zend-session`.
 
 ## 2.8.4 - 2018-01-31

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -360,7 +360,7 @@ class SessionConfig extends StandardConfig
              * "0" and "1" refer to MD5-128 and SHA1-160, respectively, and are
              * valid in addition to whatever is reported by hash_algos()
              */
-            $this->validHashFunctions = ['0', '1'] + hash_algos();
+            $this->validHashFunctions = array_merge(['0', '1'], hash_algos());
         }
         return $this->validHashFunctions;
     }

--- a/test/Config/SessionConfigTest.php
+++ b/test/Config/SessionConfigTest.php
@@ -720,7 +720,7 @@ class SessionConfigTest extends TestCase
 
     public function hashFunctions()
     {
-        $hashFunctions = [0, 1] + hash_algos();
+        $hashFunctions = array_merge([0, 1], hash_algos());
         $provider      = [];
         foreach ($hashFunctions as $function) {
             $provider[] = [$function];

--- a/test/Config/StandardConfigTest.php
+++ b/test/Config/StandardConfigTest.php
@@ -432,7 +432,7 @@ class StandardConfigTest extends TestCase
 
     public function hashFunctions()
     {
-        $hashFunctions = [0, 1] + hash_algos();
+        $hashFunctions = array_merge([0, 1], hash_algos());
         $provider      = [];
         foreach ($hashFunctions as $function) {
             $provider[] = [$function];


### PR DESCRIPTION
The `+` operator does not renumber array keys.
The keys that existed on the left side will replace fields from the
right hand side with the same keys.

On my installation, `md2` and `md4` would left out of the final result.

This was detected by static analysis (Phan dev-master). I don't have a personal use case
for md2/md4.

```php
php > echo count(array_merge([0,1], hash_algos()));
54
php > echo count([0,1] + hash_algos());
52
```

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior. (md2 and md4 aren't allowed hashes for SessionConfig->setHashFunction, probably unintentionally)
  - [x] Detail the new, expected behavior. (md2/md4 are allowed)
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
