### PR TITLE
Fix the configuration index name

### DIFF
--- a/docs/book/manager.md
+++ b/docs/book/manager.md
@@ -29,7 +29,7 @@ options in your local or global config:
 use Zend\Session;
 
 return [
-    'session_manager' => [
+    'session' => [
         'config' => [
             'class' => Session\Config\SessionConfig::class,
             'options' => [


### PR DESCRIPTION
Looks like the example code in `bootstrapSession()` expects to read a key `session`and not `session_manager` from the configuration.

Provide a narrative description of what you are trying to accomplish:

- [x] Documentation enhacement
